### PR TITLE
Stop hostapd and dnsmasq

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+wb-nm-helper (1.0.3) stable; urgency=medium
+
+  * Stop hostapd and dnsmasq after removing wlan0 from /etc/network/interfaces
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 10 Nov 2022 11:00:57 +0500
+
 wb-nm-helper (1.0.2) stable; urgency=medium
 
-  * 
+  * Fix connection creation error
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 09 Nov 2022 20:52:29 +0500
 

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import os
 import time
 from collections import namedtuple
 from enum import Enum
@@ -207,10 +206,6 @@ class Connection:
         set_ipv4_dbus_options(con, iface)
 
     def create(self, iface: JSONSettings) -> dbus.Dictionary:
-        # A new WiFi AP will be created
-        # NM conflicts with dnsmasq and hostapd so stop them
-        os.system("systemctl stop hostapd")
-        os.system("systemctl stop dnsmasq")
         con = DBUSSettings()
         self.set_dbus_options(con, iface)
         con.set_value("connection.type", self.dbus_type)

--- a/wb/nm_helper/nm_helper.py
+++ b/wb/nm_helper/nm_helper.py
@@ -1,13 +1,36 @@
 import json
 import logging
 import os
+import re
 import sys
+from typing import List
 
 from .network_interfaces_adapter import NetworkInterfacesAdapter
 from .network_manager_adapter import NetworkManagerAdapter
 
 JSON_INDENT_LEVEL = 2
 CONNECTION_MANAGER_CONFIG_FILE = "/etc/wb-connection-manager.conf"
+
+
+def find_interface_strings(file_name: str) -> List[str]:
+    res = []
+    pattern = re.compile(r"^\s*interface\s*=\s*(.*)")
+    try:
+        with open(file_name, "r", encoding="utf-8") as file:
+            for line in file.readlines():
+                match = pattern.search(line.strip())
+                if match and match.group(1):
+                    res.append(match.group(1))
+    except FileNotFoundError:
+        pass
+    return res
+
+
+def not_fully_contains(dst: List[str], src: List[str]) -> bool:
+    for item in src:
+        if item not in dst:
+            return True
+    return False
 
 
 def get_adapters():
@@ -58,11 +81,14 @@ def from_json():
     network_interfaces = NetworkInterfacesAdapter.probe()
     if network_interfaces is not None:
         apply_res = network_interfaces.apply(connections)
-        os.system("systemctl restart networking")
-        if "wlan0" not in apply_res.managed_wlans:
-            # NM conflicts with dnsmasq and hostapd, so stop them
-            os.system("systemctl stop hostapd")
+        # NM conflicts with dnsmasq and hostapd
+        # Stop them if wlan is not configured in /etc/network/interfaces
+        if not_fully_contains(apply_res.managed_wlans, find_interface_strings("/etc/dnsmasq.conf")):
             os.system("systemctl stop dnsmasq")
+        if not_fully_contains(apply_res.managed_wlans, find_interface_strings("/etc/hostapd.conf")):
+            os.system("systemctl stop hostapd")
+        os.system("systemctl restart networking")
+
         connections = apply_res.unmanaged_connections
 
     network_manager = NetworkManagerAdapter.probe()


### PR DESCRIPTION
По умолчанию у нас настроена точка доступа на wlan0. Для обеспечения её работы запущены hostapd и dnsmasq. Если удалить запись о ней из /etc/netwrok/interfaces, то запустится аналогичная точка доступа, описанная в настройках NetworkManager. NM запускает свой экземпляр dnsmasq, в результате их будет 2 одновременно запущенных. Это ломает работу сети. Так что останавливаем hostapd и dnsmasq, если wlan0 убрали из interfaces.