### PR TITLE
Fix displaying of Wi-Fi AP password

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.0.5) stable; urgency=medium
+
+  * Fix displaying of Wi-Fi AP password
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 11 Nov 2022 15:06:01 +0500
+
 wb-nm-helper (1.0.4) stable; urgency=medium
 
   * Stop hostapd and dnsmasq after removing wlan0 from /etc/network/interfaces

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -55,6 +55,9 @@
                         "hidden": true,
                         "dependencies": {
                             "security": "wpa-psk"
+                        },
+                        "wb": {
+                            "show_editor": true
                         }
                     }
                 },
@@ -66,6 +69,9 @@
                     "options": {
                         "dependencies": {
                             "key-mgmt": "wpa-psk"
+                        },
+                        "wb": {
+                            "show_editor": true
                         }
                     },
                     "propertyOrder": 2


### PR DESCRIPTION
Если была настроена точка доступа без пароля, при выборе WPA2, не появлялось поле ввода для пароля