### PR TITLE
Do not show default configured loopback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.0.6) stable; urgency=medium
+
+  * Do not show default configured loopback
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 14 Nov 2022 10:43:05 +0500
+
 wb-nm-helper (1.0.5) stable; urgency=medium
 
   * Fix displaying of Wi-Fi AP password


### PR DESCRIPTION
Решили, что не будем показывать loopback, если он настроен без особенностей в /etc/network/interfaces