### PR TITLE
Fix Wi-Fi access point security parameters editing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.10.2) stable; urgency=medium
+
+  * Fix Wi-Fi access point security parameters editing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 06 Dec 2022 12:42:58 +0500
+
 wb-nm-helper (1.10.1) stable; urgency=medium
 
   * Fix editing wlans defined in /etc/network/interfaces

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: wb-nm-helper
 Section: admin
 Priority: optional
 Maintainer: Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>
-Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config, config-package-dev
+Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config, config-package-dev, python3-pytest, python3-dbus
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-nm-helper
 

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -1,0 +1,100 @@
+import dbus
+import pytest
+
+from wb.nm_helper.network_manager_adapter import DBUSSettings, JSONSettings, WiFiAp
+
+
+def test_wifiap_set_dbus_options():
+    cases = [
+        # Remove WPA-PSK security
+        {
+            "json": {
+                "802-11-wireless-security": {"security": "none"},
+                "802-11-wireless_mode": "ap",
+                "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
+                "connection_interface-name": "wlan0",
+                "ipv4": {"method": "shared"},
+                "type": "04_nm_wifi_ap",
+                "connection_autoconnect": False,
+                "connection_id": "wb-ap",
+                "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
+            },
+            "dbus_old": dbus.Dictionary(
+                {
+                    dbus.String("connection"): dbus.Dictionary(
+                        {
+                            dbus.String("autoconnect"): dbus.Boolean(False, variant_level=1),
+                            dbus.String("id"): dbus.String("wb-ap", variant_level=1),
+                            dbus.String("interface-name"): dbus.String("wlan0", variant_level=1),
+                            dbus.String("type"): dbus.String("802-11-wireless", variant_level=1),
+                            dbus.String("uuid"): dbus.String(
+                                "d12c8d3c-1abe-4832-9b71-4ed6e3c20885", variant_level=1
+                            ),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("802-11-wireless"): dbus.Dictionary(
+                        {
+                            dbus.String("mode"): dbus.String("ap", variant_level=1),
+                            dbus.String("security"): dbus.String("802-11-wireless-security", variant_level=1),
+                            dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("802-11-wireless-security"): dbus.Dictionary(
+                        {dbus.String("key-mgmt"): dbus.String("wpa-psk", variant_level=1)},
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("ipv4"): dbus.Dictionary(
+                        {
+                            dbus.String("address-data"): dbus.Array(
+                                [], signature=dbus.Signature("a{sv}"), variant_level=1
+                            ),
+                            dbus.String("addresses"): dbus.Array(
+                                [], signature=dbus.Signature("au"), variant_level=1
+                            ),
+                            dbus.String("method"): dbus.String("shared", variant_level=1),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                },
+                signature=dbus.Signature("sa{sv}"),
+            ),
+            "dbus_new": dbus.Dictionary(
+                {
+                    dbus.String("connection"): dbus.Dictionary(
+                        {
+                            dbus.String("autoconnect"): False,
+                            dbus.String("id"): "wb-ap",
+                            dbus.String("interface-name"): "wlan0",
+                            dbus.String("type"): dbus.String("802-11-wireless", variant_level=1),
+                            dbus.String("uuid"): "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("802-11-wireless"): dbus.Dictionary(
+                        {
+                            dbus.String("mode"): "ap",
+                            dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("ipv4"): dbus.Dictionary(
+                        {
+                            dbus.String("method"): "shared",
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                },
+                signature=dbus.Signature("sa{sv}"),
+            ),
+        },
+    ]
+
+    ap = WiFiAp()
+    for test_case in cases:
+        json = JSONSettings(test_case["json"])
+        dbus_old = DBUSSettings(test_case["dbus_old"])
+        dbus_new = DBUSSettings(test_case["dbus_new"])
+        ap.set_dbus_options(dbus_old, json)
+        assert dbus_old.params == dbus_new.params

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -4,11 +4,12 @@ import pytest
 from wb.nm_helper.network_manager_adapter import DBUSSettings, JSONSettings, WiFiAp
 
 
-def test_wifiap_set_dbus_options():
-    cases = [
+@pytest.mark.parametrize(
+    "json,dbus_old,dbus_new",
+    [
         # Remove WPA-PSK security
-        {
-            "json": {
+        (
+            {
                 "802-11-wireless-security": {"security": "none"},
                 "802-11-wireless_mode": "ap",
                 "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
@@ -19,7 +20,7 @@ def test_wifiap_set_dbus_options():
                 "connection_id": "wb-ap",
                 "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
             },
-            "dbus_old": dbus.Dictionary(
+            dbus.Dictionary(
                 {
                     dbus.String("connection"): dbus.Dictionary(
                         {
@@ -60,7 +61,7 @@ def test_wifiap_set_dbus_options():
                 },
                 signature=dbus.Signature("sa{sv}"),
             ),
-            "dbus_new": dbus.Dictionary(
+            dbus.Dictionary(
                 {
                     dbus.String("connection"): dbus.Dictionary(
                         {
@@ -88,13 +89,13 @@ def test_wifiap_set_dbus_options():
                 },
                 signature=dbus.Signature("sa{sv}"),
             ),
-        },
-    ]
-
+        )
+    ],
+)
+def test_wifiap_set_dbus_options(json, dbus_old, dbus_new):
     ap = WiFiAp()
-    for test_case in cases:
-        json = JSONSettings(test_case["json"])
-        dbus_old = DBUSSettings(test_case["dbus_old"])
-        dbus_new = DBUSSettings(test_case["dbus_new"])
-        ap.set_dbus_options(dbus_old, json)
-        assert dbus_old.params == dbus_new.params
+    json_settings = JSONSettings(json)
+    dbus_old_settings = DBUSSettings(dbus_old)
+    dbus_new_settings = DBUSSettings(dbus_new)
+    ap.set_dbus_options(dbus_old_settings, json_settings)
+    assert dbus_old_settings.params == dbus_new_settings.params


### PR DESCRIPTION
При отключении WPA-PSK формировались настройки с пустым объектом `802-11-wireless-security`. NM ругался, что в объекте должны быть обязательные параметры, или его не должно быть совсем.