### PR TITLE
Fix Wi-Fi access point's subnet address editing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.10.3) stable; urgency=medium
+
+  * Fix Wi-Fi access point's subnet address editing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 06 Dec 2022 18:31:32 +0500
+
 wb-nm-helper (1.10.2) stable; urgency=medium
 
   * Fix Wi-Fi access point security parameters editing

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -89,7 +89,93 @@ from wb.nm_helper.network_manager_adapter import DBUSSettings, JSONSettings, WiF
                 },
                 signature=dbus.Signature("sa{sv}"),
             ),
-        )
+        ),
+        # Set Wi-Fi AP subnet address
+        (
+            {
+                "802-11-wireless-security": {"security": "none"},
+                "802-11-wireless_mode": "ap",
+                "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
+                "connection_interface-name": "wlan0",
+                "ipv4": {"method": "shared", "address": "192.168.42.1"},
+                "type": "04_nm_wifi_ap",
+                "connection_autoconnect": False,
+                "connection_id": "wb-ap",
+                "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
+            },
+            dbus.Dictionary(
+                {
+                    dbus.String("connection"): dbus.Dictionary(
+                        {
+                            dbus.String("autoconnect"): dbus.Boolean(False, variant_level=1),
+                            dbus.String("id"): dbus.String("wb-ap", variant_level=1),
+                            dbus.String("interface-name"): dbus.String("wlan0", variant_level=1),
+                            dbus.String("type"): dbus.String("802-11-wireless", variant_level=1),
+                            dbus.String("uuid"): dbus.String(
+                                "d12c8d3c-1abe-4832-9b71-4ed6e3c20885", variant_level=1
+                            ),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("802-11-wireless"): dbus.Dictionary(
+                        {
+                            dbus.String("mode"): dbus.String("ap", variant_level=1),
+                            dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("ipv4"): dbus.Dictionary(
+                        {
+                            dbus.String("address-data"): dbus.Array(
+                                [], signature=dbus.Signature("a{sv}"), variant_level=1
+                            ),
+                            dbus.String("addresses"): dbus.Array(
+                                [], signature=dbus.Signature("au"), variant_level=1
+                            ),
+                            dbus.String("method"): dbus.String("shared", variant_level=1),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                },
+                signature=dbus.Signature("sa{sv}"),
+            ),
+            dbus.Dictionary(
+                {
+                    dbus.String("connection"): dbus.Dictionary(
+                        {
+                            dbus.String("autoconnect"): False,
+                            dbus.String("id"): "wb-ap",
+                            dbus.String("interface-name"): "wlan0",
+                            dbus.String("type"): dbus.String("802-11-wireless", variant_level=1),
+                            dbus.String("uuid"): "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("802-11-wireless"): dbus.Dictionary(
+                        {
+                            dbus.String("mode"): "ap",
+                            dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("ipv4"): dbus.Dictionary(
+                        {
+                            dbus.String("method"): "shared",
+                            dbus.String("address-data"): dbus.Array(
+                                [
+                                    dbus.Dictionary(
+                                        {"address": "192.168.42.1", "prefix": dbus.UInt32(24)}, signature=None
+                                    )
+                                ],
+                                signature=dbus.Signature("a{sv}"),
+                            ),
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                },
+                signature=dbus.Signature("sa{sv}"),
+            ),
+        ),
     ],
 )
 def test_wifiap_set_dbus_options(json, dbus_old, dbus_new):

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -168,7 +168,8 @@ def set_ipv4_dbus_options(con: DBUSSettings, iface: JSONSettings) -> None:
     # remove deprecated parameter ipv4.addresses
     con.set_value("ipv4.addresses", None)
     con.set_opts(iface, ipv4_params)
-    if iface.get_opt("ipv4.method", "auto") == "manual":
+    method = iface.get_opt("ipv4.method", "auto")
+    if (method == "manual") or (method == "shared" and iface.get_opt("ipv4.address") is not None):
         net = IPv4Interface(
             "%s/%s" % (iface.get_opt("ipv4.address"), iface.get_opt("ipv4.netmask", "255.255.255.0"))
         )


### PR DESCRIPTION
У AP метод `shared`, и можно указать адрес, но адреса может и не быть, тогда NM ставит его по умолчанию. Я адрес записывал только, если метод `manual`.