### PR TITLE
Fix parsing of /etc/network/interfaces

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.10.5) stable; urgency=medium
+
+  * Fix parsing of /etc/network/interfaces without new line at the end of a file
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 19 Dec 2022 17:51:10 +0500
+
 wb-nm-helper (1.10.4) stable; urgency=medium
 
   * Disable WPS for Wi-Fi access points.

--- a/tests/data/interfaces_no_newline
+++ b/tests/data/interfaces_no_newline
@@ -1,0 +1,3 @@
+allow-hotplug can0
+iface can0 can static
+ bitrate 125000

--- a/tests/test_network_interfaces_adapter.py
+++ b/tests/test_network_interfaces_adapter.py
@@ -1,0 +1,29 @@
+import dbus
+import pytest
+
+from wb.nm_helper.network_interfaces_adapter import NetworkInterfacesAdapter
+
+
+@pytest.mark.parametrize(
+    "file_name,connections",
+    [
+        (
+            # no new line at the end of file
+            "tests/data/interfaces_no_newline",
+            [
+                {
+                    "allow-hotplug": True,
+                    "auto": False,
+                    "method": "static",
+                    "mode": "can",
+                    "name": "can0",
+                    "options": {"bitrate": "125000"},
+                    "type": "can",
+                }
+            ],
+        )
+    ],
+)
+def test_parsing(file_name, connections):
+    adapter = NetworkInterfacesAdapter(file_name)
+    assert adapter.get_connections() == connections

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -90,12 +90,10 @@ class NetworkInterfacesAdapter:
 
     interface_file = ZeroOrMore(interface_block).ignore(pythonStyleComment)
 
-    def __init__(self, input_file_name=None, content=None):
+    def __init__(self, input_file_name=None):
         self.filename = None
-        self.content = None
-        if content:
-            self.content = content
-        elif input_file_name is not None:
+        self.content = "\n"
+        if input_file_name is not None:
             self.filename = input_file_name
             self._read()
         if self.content is not None:
@@ -107,6 +105,8 @@ class NetworkInterfacesAdapter:
         """
         with open(self.filename, "r", encoding="utf-8") as file:
             self.content = file.read()
+        if not self.content.endswith("\n"):
+            self.content = self.content + "\n"
 
     def get(self):
         """


### PR DESCRIPTION
Fix parsing of /etc/network/interfaces without new line at the end of a file

Если нет новой строки в конце файла, парсер не разбирает эту строку