### PR TITLE
Increase Wi-Fi scan timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.10.6) stable; urgency=medium
+
+  * Increase Wi-Fi scan timeout
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 20 Dec 2022 10:27:43 +0500
+
 wb-nm-helper (1.10.5) stable; urgency=medium
 
   * Fix parsing of /etc/network/interfaces without new line at the end of a file

--- a/wb/nm_helper/nm_helper.py
+++ b/wb/nm_helper/nm_helper.py
@@ -12,7 +12,7 @@ from typing import List
 from .network_interfaces_adapter import NetworkInterfacesAdapter
 from .network_manager_adapter import NetworkManagerAdapter
 
-WIFI_SCAN_TIMEOUT = datetime.timedelta(seconds=5)
+WIFI_SCAN_TIMEOUT = datetime.timedelta(seconds=10)
 
 JSON_INDENT_LEVEL = 2
 CONNECTION_MANAGER_CONFIG_FILE = "/etc/wb-connection-manager.conf"
@@ -44,7 +44,7 @@ def scan_wifi() -> List[str]:
     try:
         pattern = re.compile(r"ESSID:\s*\"(.*)\"")
         scan_result = subprocess.check_output(
-            ["iwlist", "scan"], timeout=WIFI_SCAN_TIMEOUT.total_seconds(), text=True
+            ["iwlist", "wlan0", "scan"], timeout=WIFI_SCAN_TIMEOUT.total_seconds(), text=True
         )
         for line in scan_result.splitlines():
             match = pattern.search(line)


### PR DESCRIPTION
* Увеличил таймаут, т.к. при свободных wlan0 и wlan1 сканирование может длиться больше 5 секунд.
* Сканирую только через wlan0, что уменьшает время сканирования