### PR TITLE
Add tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ wb-nm-helper (1.12.0) stable; urgency=medium
 
   * Add arguments to wb-nm-helper
   * Increase default Wi-Fi scan timeout
+  * Add nm_helper tests
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 23 Dec 2022 10:27:43 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ wb-nm-helper (1.12.0) stable; urgency=medium
   * Add arguments to wb-nm-helper
   * Increase default Wi-Fi scan timeout
   * Add nm_helper tests
+  * Restart networking.service and NetworkManager.service only if required
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 23 Dec 2022 10:27:43 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,6 @@ wb-nm-helper (1.12.0) stable; urgency=medium
   * Add arguments to wb-nm-helper
   * Increase default Wi-Fi scan timeout
   * Add nm_helper tests
-  * Restart networking.service and NetworkManager.service only if required
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 26 Dec 2022 10:27:43 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-nm-helper (1.12.0) stable; urgency=medium
+
+  * Add arguments to wb-nm-helper
+  * Increase default Wi-Fi scan timeout
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 23 Dec 2022 10:27:43 +0400
+
 wb-nm-helper (1.11.1) stable; urgency=medium
 
   * Add route metric editing to IPv4 DHCP and shared connections

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: wb-nm-helper
 Section: admin
 Priority: optional
 Maintainer: Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>
-Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config, config-package-dev, python3-pytest, python3-dbus
+Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config, config-package-dev, python3-pytest, python3-dbus, python3-dbusmock
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-nm-helper
 

--- a/tests/data/interfaces
+++ b/tests/data/interfaces
@@ -1,0 +1,37 @@
+# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)
+
+# The loopback interface
+auto lo
+iface lo inet loopback
+
+# Wireless interfaces
+allow-hotplug wlan0
+
+#iface wlan0 inet dhcp
+#    wpa-ssid wifiessid
+#    wpa-psk wifipassword
+
+iface wlan0 inet static
+  address 192.168.42.1
+  netmask 255.255.255.0
+
+
+auto eth0
+allow-hotplug eth0
+iface eth0 inet dhcp
+   pre-up wb-set-mac
+   hostname WirenBoard
+
+allow-hotplug eth1
+iface eth1 inet dhcp
+   pre-up wb-set-mac
+   hostname WirenBoard
+
+
+## The gsm pptp interface
+## vvv uncomment block to enable
+
+#auto ppp0
+#iface ppp0 inet ppp
+## select provider: megafon, mts or beeline below
+#  provider megafon

--- a/tests/data/ui.json
+++ b/tests/data/ui.json
@@ -1,0 +1,136 @@
+{
+  "data": {
+    "devices": [
+      {
+        "iface": "eth0",
+        "type": "ethernet"
+      },
+      {
+        "iface": "eth1",
+        "type": "ethernet"
+      },
+      {
+        "iface": "wlan0",
+        "type": "wifi"
+      },
+      {
+        "iface": "wlan1",
+        "type": "wifi"
+      }
+    ],
+    "ssids": []
+  },
+  "ui": {
+    "con_switch": {
+      "connections": [],
+      "debug": false
+    },
+    "connections": [
+      {
+        "connection_interface-name": "eth0",
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "01_nm_ethernet",
+        "connection_autoconnect": true,
+        "connection_id": "wb-eth0",
+        "connection_uuid": "91f1c71d-2d97-4675-886f-ecbe52b8451e"
+      },
+      {
+        "connection_interface-name": "eth1",
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "01_nm_ethernet",
+        "connection_autoconnect": true,
+        "connection_id": "wb-eth1",
+        "connection_uuid": "c3e38405-9c17-4155-ad70-664311b49066"
+      },
+      {
+        "connection_interface-name": "",
+        "gsm_auto-config": true,
+        "gsm_sim-slot": 1,
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "02_nm_modem",
+        "connection_autoconnect": false,
+        "connection_id": "wb-gsm-sim1",
+        "connection_uuid": "5d4297ba-c319-4c05-a153-17cb42e6e196"
+      },
+      {
+        "connection_interface-name": "",
+        "gsm_auto-config": true,
+        "gsm_sim-slot": 2,
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "02_nm_modem",
+        "connection_autoconnect": false,
+        "connection_id": "wb-gsm-sim2",
+        "connection_uuid": "8b9964d4-b8dd-34d3-a3ed-481840bcf8c9"
+      },
+      {
+        "802-11-wireless-security": {
+          "security": "none"
+        },
+        "802-11-wireless_mode": "ap",
+        "802-11-wireless_ssid": "WirenBoard-XXXXXXXX",
+        "connection_interface-name": "wlan0",
+        "ipv4": {
+          "address": "192.168.42.1",
+          "method": "shared",
+          "netmask": "255.255.255.0"
+        },
+        "type": "04_nm_wifi_ap",
+        "connection_autoconnect": true,
+        "connection_id": "wb-ap",
+        "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885"
+      },
+      {
+        "name": "eth0",
+        "auto": true,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hostname": "WirenBoard",
+          "pre-up": "wb-set-mac"
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
+        "name": "eth1",
+        "auto": false,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hostname": "WirenBoard",
+          "pre-up": "wb-set-mac"
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
+        "name": "wlan0",
+        "auto": true,
+        "mode": "inet",
+        "method": "static",
+        "options": {
+          "address": "192.168.42.1",
+          "netmask": "255.255.255.0"
+        },
+        "allow-hotplug": true,
+        "type": "static"
+      }
+    ]
+  }
+}

--- a/tests/data/wb-connection-manager.conf
+++ b/tests/data/wb-connection-manager.conf
@@ -1,0 +1,5 @@
+{
+  "connections": [
+  ],
+  "debug": false
+}

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -234,8 +234,13 @@ class TestNetworkManagerHelperExport(dbusmock.DBusTestCase):
             interfaces_conf="tests/data/interfaces",
             dnsmasq_conf="tests/data/dnsmasq.conf",
             hostapd_conf="tests/data/hostapd.conf",
+            state_file="tests/data/wb-nm-helper.json",
             dry_run=True
         ))
 
         assert len(res["connections"]) == 0
         assert res["debug"] == False
+
+        with open("tests/data/wb-nm-helper.json", "r") as f:
+            state = json.load(f)
+        assert state["count"] == 3

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -234,13 +234,8 @@ class TestNetworkManagerHelperExport(dbusmock.DBusTestCase):
             interfaces_conf="tests/data/interfaces",
             dnsmasq_conf="tests/data/dnsmasq.conf",
             hostapd_conf="tests/data/hostapd.conf",
-            state_file="tests/data/wb-nm-helper.json",
             dry_run=True
         ))
 
         assert len(res["connections"]) == 0
         assert res["debug"] == False
-
-        with open("tests/data/wb-nm-helper.json", "r") as f:
-            state = json.load(f)
-        assert state["count"] == 3

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -1,0 +1,241 @@
+import argparse
+import json
+import subprocess
+
+import dbus
+import dbusmock
+
+from dbusmock.templates.networkmanager import DeviceState
+from dbusmock.templates.networkmanager import (CSETTINGS_IFACE, MANAGER_IFACE,
+                                               SETTINGS_OBJ, SETTINGS_IFACE)
+
+from wb.nm_helper.nm_helper import from_json, to_json
+
+
+class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.start_system_bus()
+        cls.system_bus = cls.get_dbus(system_bus=True)
+
+    def setUp(self):
+        self.p_mock = None
+
+    def tearDown(self):
+        if self.p_mock:
+            self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+            self.p_mock = None
+
+    def test_to_json(self):
+        (self.p_mock, self.obj_networkmanager) = self.spawn_server_template(
+            "networkmanager", {"NetworkingEnabled": True}, stdout=subprocess.PIPE)
+        self.networkmanager_mock = dbus.Interface(self.obj_networkmanager, dbusmock.MOCK_IFACE)
+        self.settings = dbus.Interface(
+            self.system_bus.get_object(MANAGER_IFACE, SETTINGS_OBJ),
+            SETTINGS_IFACE)
+
+        self.networkmanager_mock.AddEthernetDevice("mock_eth0", "eth0", DeviceState.ACTIVATED)
+        self.networkmanager_mock.AddEthernetDevice("mock_eth1", "eth1", DeviceState.ACTIVATED)
+        self.networkmanager_mock.AddWiFiDevice("mock_wlan0", "wlan0", DeviceState.ACTIVATED)
+        self.networkmanager_mock.AddWiFiDevice("mock_wlan1", "wlan1", DeviceState.ACTIVATED)
+
+        self.settings.AddConnection(dbus.Dictionary({
+            "connection": dbus.Dictionary({
+                "id": dbus.String("wb-eth0", variant_level=1),
+                "interface-name": dbus.String("eth0", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("91f1c71d-2d97-4675-886f-ecbe52b8451e", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "ipv4": dbus.Dictionary({
+                "method": dbus.String("auto", variant_level=1)
+            }, signature=dbus.Signature("sv"))
+        }, signature=dbus.Signature("sa{sv}")))
+
+        self.settings.AddConnection(dbus.Dictionary({
+            "connection": dbus.Dictionary({
+                "id": dbus.String("wb-eth1", variant_level=1),
+                "interface-name": dbus.String("eth1", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("c3e38405-9c17-4155-ad70-664311b49066", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "ipv4": dbus.Dictionary({
+                "method": dbus.String("auto", variant_level=1)
+            }, signature=dbus.Signature("sv"))
+        }, signature=dbus.Signature("sa{sv}")))
+
+        self.settings.AddConnection(dbus.Dictionary({
+            "connection": dbus.Dictionary({
+                "autoconnect": dbus.Boolean(False, variant_level=1),
+                "id": dbus.String("wb-gsm-sim1", variant_level=1),
+                "type": "gsm",
+                "uuid": dbus.String("5d4297ba-c319-4c05-a153-17cb42e6e196", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "gsm": dbus.Dictionary({
+                "auto-config": dbus.Boolean(True, variant_level=1),
+                "sim-slot": dbus.Int32(1, variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "ipv4": dbus.Dictionary({
+                "method": dbus.String("auto", variant_level=1)
+            }, signature=dbus.Signature("sv"))
+        }, signature=dbus.Signature("sa{sv}")))
+
+        self.settings.AddConnection(dbus.Dictionary({
+            "connection": dbus.Dictionary({
+                "autoconnect": dbus.Boolean(False, variant_level=1),
+                "id": dbus.String("wb-gsm-sim2", variant_level=1),
+                "type": "gsm",
+                "uuid": dbus.String("8b9964d4-b8dd-34d3-a3ed-481840bcf8c9", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "gsm": dbus.Dictionary({
+                "auto-config": dbus.Boolean(True, variant_level=1),
+                "sim-slot": dbus.Int32(2, variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "ipv4": dbus.Dictionary({
+                "method": dbus.String("auto", variant_level=1)
+            }, signature=dbus.Signature("sv"))
+        }, signature=dbus.Signature("sa{sv}")))
+
+        self.settings.AddConnection(dbus.Dictionary({
+            "connection": dbus.Dictionary({
+                "id": dbus.String("wb-ap", variant_level=1),
+                "interface-name": dbus.String("wlan0", variant_level=1),
+                "type": "802-11-wireless",
+                "uuid": dbus.String("d12c8d3c-1abe-4832-9b71-4ed6e3c20885", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "802-11-wireless": dbus.Dictionary({
+                "mode": dbus.String("ap", variant_level=1),
+                "ssid": dbus.String("WirenBoard-XXXXXXXX", variant_level=1)
+            }, signature=dbus.Signature("sv")),
+            "ipv4": dbus.Dictionary({
+                "address-data": dbus.Array([
+                    dbus.Dictionary({
+                        "address": dbus.String("192.168.42.1", variant_level=1),
+                        "prefix": dbus.Int32(24, variant_level=1)
+                    }, signature=dbus.Signature("sv"))
+                ], signature=dbus.Signature("a{sv}")),
+                "method": dbus.String("shared", variant_level=1)
+            }, signature=dbus.Signature("sv"))
+        }, signature=dbus.Signature("sa{sv}")))
+
+        res = to_json(args=argparse.Namespace(
+            config="tests/data/wb-connection-manager.conf",
+            interfaces_conf="tests/data/interfaces",
+            no_scan=True
+        ))
+
+        assert len(res["data"]["devices"]) == 4
+        assert res["data"]["devices"][0]["iface"] == "eth0"
+        assert res["data"]["devices"][0]["type"] == "ethernet"
+        assert res["data"]["devices"][1]["iface"] == "eth1"
+        assert res["data"]["devices"][1]["type"] == "ethernet"
+        assert res["data"]["devices"][2]["iface"] == "wlan0"
+        assert res["data"]["devices"][2]["type"] == "wifi"
+        assert res["data"]["devices"][3]["iface"] == "wlan1"
+        assert res["data"]["devices"][3]["type"] == "wifi"
+        assert res["ui"]["con_switch"]["debug"] == False
+        assert len(res["ui"]["connections"]) == 8
+        assert res["ui"]["connections"][0]["802-11-wireless-security"]["security"] == "none"
+        assert res["ui"]["connections"][0]["802-11-wireless_mode"] == "ap"
+        assert res["ui"]["connections"][0]["802-11-wireless_ssid"] == "WirenBoard-XXXXXXXX"
+        assert res["ui"]["connections"][0]["connection_autoconnect"] == True
+        assert res["ui"]["connections"][0]["connection_id"] == "wb-ap"
+        assert res["ui"]["connections"][0]["connection_interface-name"] == "wlan0"
+        assert res["ui"]["connections"][0]["connection_uuid"] == "d12c8d3c-1abe-4832-9b71-4ed6e3c20885"
+        assert res["ui"]["connections"][0]["ipv4"]["address"] == "192.168.42.1"
+        assert res["ui"]["connections"][0]["ipv4"]["method"] == "shared"
+        assert res["ui"]["connections"][0]["ipv4"]["netmask"] == "255.255.255.0"
+        assert res["ui"]["connections"][0]["type"] == "04_nm_wifi_ap"
+        assert res["ui"]["connections"][1]["connection_autoconnect"] == True
+        assert res["ui"]["connections"][1]["connection_id"] == "wb-eth0"
+        assert res["ui"]["connections"][1]["connection_interface-name"] == "eth0"
+        assert res["ui"]["connections"][1]["connection_uuid"] == "91f1c71d-2d97-4675-886f-ecbe52b8451e"
+        assert res["ui"]["connections"][1]["ipv4"]["method"] == "auto"
+        assert res["ui"]["connections"][1]["type"] == "01_nm_ethernet"
+        assert res["ui"]["connections"][2]["connection_autoconnect"] == True
+        assert res["ui"]["connections"][2]["connection_id"] == "wb-eth1"
+        assert res["ui"]["connections"][2]["connection_interface-name"] == "eth1"
+        assert res["ui"]["connections"][2]["connection_uuid"] == "c3e38405-9c17-4155-ad70-664311b49066"
+        assert res["ui"]["connections"][2]["ipv4"]["method"] == "auto"
+        assert res["ui"]["connections"][2]["type"] == "01_nm_ethernet"
+        assert res["ui"]["connections"][3]["connection_autoconnect"] == False
+        assert res["ui"]["connections"][3]["connection_id"] == "wb-gsm-sim1"
+        assert res["ui"]["connections"][3]["connection_uuid"] == "5d4297ba-c319-4c05-a153-17cb42e6e196"
+        assert res["ui"]["connections"][3]["gsm_auto-config"] == True
+        assert res["ui"]["connections"][3]["gsm_sim-slot"] == 1
+        assert res["ui"]["connections"][3]["ipv4"]["method"] == "auto"
+        assert res["ui"]["connections"][3]["type"] == "02_nm_modem"
+        assert res["ui"]["connections"][4]["connection_autoconnect"] == False
+        assert res["ui"]["connections"][4]["connection_id"] == "wb-gsm-sim2"
+        assert res["ui"]["connections"][4]["connection_uuid"] == "8b9964d4-b8dd-34d3-a3ed-481840bcf8c9"
+        assert res["ui"]["connections"][4]["gsm_auto-config"] == True
+        assert res["ui"]["connections"][4]["gsm_sim-slot"] == 2
+        assert res["ui"]["connections"][4]["ipv4"]["method"] == "auto"
+        assert res["ui"]["connections"][4]["type"] == "02_nm_modem"
+        assert res["ui"]["connections"][5]["allow-hotplug"] == True
+        assert res["ui"]["connections"][5]["auto"] == False
+        assert res["ui"]["connections"][5]["method"] == "static"
+        assert res["ui"]["connections"][5]["mode"] == "inet"
+        assert res["ui"]["connections"][5]["name"] == "wlan0"
+        assert res["ui"]["connections"][5]["options"]["address"] == "192.168.42.1"
+        assert res["ui"]["connections"][5]["options"]["netmask"] == "255.255.255.0"
+        assert res["ui"]["connections"][5]["type"] == "static"
+        assert res["ui"]["connections"][6]["allow-hotplug"] == True
+        assert res["ui"]["connections"][6]["auto"] == True
+        assert res["ui"]["connections"][6]["method"] == "dhcp"
+        assert res["ui"]["connections"][6]["mode"] == "inet"
+        assert res["ui"]["connections"][6]["name"] == "eth0"
+        assert res["ui"]["connections"][6]["options"]["hostname"] == "WirenBoard"
+        assert res["ui"]["connections"][6]["options"]["pre-up"] == "wb-set-mac"
+        assert res["ui"]["connections"][6]["type"] == "dhcp"
+        assert res["ui"]["connections"][7]["allow-hotplug"] == True
+        assert res["ui"]["connections"][7]["auto"] == False
+        assert res["ui"]["connections"][7]["method"] == "dhcp"
+        assert res["ui"]["connections"][7]["mode"] == "inet"
+        assert res["ui"]["connections"][7]["name"] == "eth1"
+        assert res["ui"]["connections"][7]["options"]["hostname"] == "WirenBoard"
+        assert res["ui"]["connections"][7]["options"]["pre-up"] == "wb-set-mac"
+        assert res["ui"]["connections"][7]["type"] == "dhcp"
+
+
+class TestNetworkManagerHelperExport(dbusmock.DBusTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.start_system_bus()
+        cls.system_bus = cls.get_dbus(system_bus=True)
+
+    def setUp(self):
+        self.p_mock = None
+
+    def tearDown(self):
+        if self.p_mock:
+            self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+            self.p_mock = None
+
+    def test_from_json(self):
+        # TODO: set dry_run=False
+        # python3-dbusmock >= 0.23.0 is required, but Debian Bullseye ships 0.22.0
+        # (self.p_mock, self.obj_systemd) = self.spawn_server_template(
+        #     "systemd", {}, stdout=subprocess.PIPE)
+        # self.systemd_mock = dbus.Interface(self.obj_systemd, dbusmock.MOCK_IFACE)
+        # self.systemd_mock.AddMockUnit("NetworkManager.service")
+        # self.systemd_mock.AddMockUnit("networking.service")
+        # self.systemd_mock.AddMockUnit("dnsmasq.service")
+        # self.systemd_mock.AddMockUnit("hostapd.service")
+        # self.systemd_mock.AddMockUnit("wb-connection-manager.service")
+
+        with open("tests/data/ui.json", "r") as f:
+            cfg = json.load(f)
+
+        res = from_json(cfg, args=argparse.Namespace(
+            interfaces_conf="tests/data/interfaces",
+            dnsmasq_conf="tests/data/dnsmasq.conf",
+            hostapd_conf="tests/data/hostapd.conf",
+            dry_run=True
+        ))
+
+        assert len(res["connections"]) == 0
+        assert res["debug"] == False

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -46,7 +46,7 @@ from pyparsing import (
 
 NETWORK_INTERFACES_CONFIG = "/etc/network/interfaces"
 
-ApplyResult = namedtuple("ApplyResult", ["unmanaged_connections", "managed_wlans"], defaults=[[], []])
+ApplyResult = namedtuple("ApplyResult", ["unmanaged_connections", "managed_interfaces"], defaults=[[], []])
 
 
 def is_default_configured_loopback(iface):
@@ -234,8 +234,7 @@ class NetworkInterfacesAdapter:
             if iface.get("type") in supported_types:
                 iface.pop("type", None)
                 self.interfaces.append(iface)
-                if iface["name"].startswith("wlan"):
-                    res.managed_wlans.append(iface["name"])
+                res.managed_interfaces.append(iface["name"])
             else:
                 res.unmanaged_connections.append(iface)
         if not dry_run:

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -28,7 +28,6 @@
 
 from collections import namedtuple
 from os.path import exists
-import os
 
 from pyparsing import (
     CharsNotIn,
@@ -230,7 +229,6 @@ class NetworkInterfacesAdapter:
     def apply(self, interfaces, dry_run: bool) -> ApplyResult:
         supported_types = ["loopback", "dhcp", "static", "can", "manual", "ppp"]
         res = ApplyResult()
-        old_iface_names = [c["name"] for c in self.interfaces]
         self.interfaces = []
         for iface in interfaces:
             if iface.get("type") in supported_types:
@@ -239,12 +237,6 @@ class NetworkInterfacesAdapter:
                 res.managed_interfaces.append(iface["name"])
             else:
                 res.unmanaged_connections.append(iface)
-
-        new_iface_names = [c["name"] for c in self.interfaces]
-        for iface in old_iface_names:
-            if iface not in new_iface_names and not dry_run:
-                os.system("ifdown %s" % iface)
-
         if not dry_run:
             with open(self.filename, "w", encoding="utf-8") as file:
                 file.write(self.format())

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -28,6 +28,7 @@
 
 from collections import namedtuple
 from os.path import exists
+import os
 
 from pyparsing import (
     CharsNotIn,
@@ -229,6 +230,7 @@ class NetworkInterfacesAdapter:
     def apply(self, interfaces, dry_run: bool) -> ApplyResult:
         supported_types = ["loopback", "dhcp", "static", "can", "manual", "ppp"]
         res = ApplyResult()
+        old_iface_names = [c["name"] for c in self.interfaces]
         self.interfaces = []
         for iface in interfaces:
             if iface.get("type") in supported_types:
@@ -237,6 +239,12 @@ class NetworkInterfacesAdapter:
                 res.managed_interfaces.append(iface["name"])
             else:
                 res.unmanaged_connections.append(iface)
+
+        new_iface_names = [c["name"] for c in self.interfaces]
+        for iface in old_iface_names:
+            if iface not in new_iface_names and not dry_run:
+                os.system("ifdown %s" % iface)
+
         if not dry_run:
             with open(self.filename, "w", encoding="utf-8") as file:
                 file.write(self.format())

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -221,12 +221,12 @@ class NetworkInterfacesAdapter:
         )
 
     @staticmethod
-    def probe():
-        if exists(NETWORK_INTERFACES_CONFIG):
-            return NetworkInterfacesAdapter(NETWORK_INTERFACES_CONFIG)
+    def probe(config: str = NETWORK_INTERFACES_CONFIG):
+        if exists(config):
+            return NetworkInterfacesAdapter(config)
         return None
 
-    def apply(self, interfaces) -> ApplyResult:
+    def apply(self, interfaces, dry_run: bool) -> ApplyResult:
         supported_types = ["loopback", "dhcp", "static", "can", "manual", "ppp"]
         res = ApplyResult()
         self.interfaces = []
@@ -238,8 +238,9 @@ class NetworkInterfacesAdapter:
                     res.managed_wlans.append(iface["name"])
             else:
                 res.unmanaged_connections.append(iface)
-        with open(NETWORK_INTERFACES_CONFIG, "w", encoding="utf-8") as file:
-            file.write(self.format())
+        if not dry_run:
+            with open(self.filename, "w", encoding="utf-8") as file:
+                file.write(self.format())
         return res
 
     def get_connections(self):

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -322,8 +322,10 @@ class ModemConnection(Connection):
         Connection.__init__(self, "gsm", METHOD_MODEM, params)
 
 
-def apply(iface, c_handler, network_manager: NetworkManager):
+def apply(iface, c_handler, network_manager: NetworkManager, dry_run: bool) -> None:
     json_settings = JSONSettings(iface)
+    if dry_run:
+        return
     if json_settings.get_opt("connection.uuid"):
         for con in network_manager.get_connections():
             dbus_settings = DBUSSettings(con.get_settings())
@@ -369,12 +371,13 @@ class NetworkManagerAdapter:
                     con.delete()
                     break
 
-    def apply(self, interfaces):
-        self.remove_undefined_connections(interfaces)
+    def apply(self, interfaces, dry_run: bool) -> None:
+        if not dry_run:
+            self.remove_undefined_connections(interfaces)
         for iface in interfaces:
             handler = self.handlers.get(iface["type"])
             if handler is not None:
-                apply(iface, handler, self.network_manager)
+                apply(iface, handler, self.network_manager, dry_run)
 
     def get_connections(self):
         res = []

--- a/wb/nm_helper/nm_helper.py
+++ b/wb/nm_helper/nm_helper.py
@@ -37,12 +37,21 @@ def not_fully_contains(dst: List[str], src: List[str]) -> bool:
     return False
 
 
-def scan_wifi(iface: str, timeout: int) -> List[str]:
+"""Scans for Wi-Fi networks
+
+:param iface - interface to scan
+:type iface: str
+:param timeout_s - timeout in seconds (if the timeout expires, the iwlist process will be killed)
+:type timeout_s: int
+:returns: a list of ESSID names or an empty list if scan failed
+:rtype: list
+"""
+def scan_wifi(iface: str, timeout_s: int) -> List[str]:
     res = []
     try:
         pattern = re.compile(r"ESSID:\s*\"(.*)\"")
         scan_result = subprocess.check_output(
-            ["iwlist", iface, "scan"], timeout=datetime.timedelta(seconds=timeout).total_seconds(), text=True
+            ["iwlist", iface, "scan"], timeout=datetime.timedelta(seconds=timeout_s).total_seconds(), text=True
         )
         for line in scan_result.splitlines():
             match = pattern.search(line)
@@ -50,7 +59,7 @@ def scan_wifi(iface: str, timeout: int) -> List[str]:
                 res.append(match.group(1))
         res = sorted(set(res))
     except subprocess.TimeoutExpired:
-        logging.info("Can't get Wi-Fi scanning results within %d", timeout)
+        logging.info("Can't get Wi-Fi scanning results within %d", timeout_s)
     except subprocess.CalledProcessError as ex:
         logging.info("Error during Wi-Fi scan: %s", ex)
     return res

--- a/wb/nm_helper/nm_helper.py
+++ b/wb/nm_helper/nm_helper.py
@@ -100,9 +100,10 @@ def from_json(cfg, args) -> dict:
         apply_res = network_interfaces.apply(connections, args.dry_run)
         # NM conflicts with dnsmasq and hostapd
         # Stop them if wlan is not configured in /etc/network/interfaces
-        if not_fully_contains(apply_res.managed_wlans, find_interface_strings(args.dnsmasq_conf)):
+        managed_wlans = [iface for iface in apply_res.managed_interfaces if iface.startswith("wlan")]
+        if not_fully_contains(managed_wlans, find_interface_strings(args.dnsmasq_conf)):
             manager.StopUnit("dnsmasq.service", "fail")
-        if not_fully_contains(apply_res.managed_wlans, find_interface_strings(args.hostapd_conf)):
+        if not_fully_contains(managed_wlans, find_interface_strings(args.hostapd_conf)):
             manager.StopUnit("hostapd.service", "fail")
         manager.RestartUnit("networking.service", "fail")
 

--- a/wb/nm_helper/nm_helper.py
+++ b/wb/nm_helper/nm_helper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import datetime
 import json
 import logging
@@ -11,11 +12,6 @@ from typing import List
 
 from .network_interfaces_adapter import NetworkInterfacesAdapter
 from .network_manager_adapter import NetworkManagerAdapter
-
-WIFI_SCAN_TIMEOUT = datetime.timedelta(seconds=5)
-
-JSON_INDENT_LEVEL = 2
-CONNECTION_MANAGER_CONFIG_FILE = "/etc/wb-connection-manager.conf"
 
 
 def find_interface_strings(file_name: str) -> List[str]:
@@ -39,12 +35,12 @@ def not_fully_contains(dst: List[str], src: List[str]) -> bool:
     return False
 
 
-def scan_wifi() -> List[str]:
+def scan_wifi(iface: str, timeout: int) -> List[str]:
     res = []
     try:
         pattern = re.compile(r"ESSID:\s*\"(.*)\"")
         scan_result = subprocess.check_output(
-            ["iwlist", "scan"], timeout=WIFI_SCAN_TIMEOUT.total_seconds(), text=True
+            ["iwlist", iface, "scan"], timeout=datetime.timedelta(seconds=timeout).total_seconds(), text=True
         )
         for line in scan_result.splitlines():
             match = pattern.search(line)
@@ -52,13 +48,13 @@ def scan_wifi() -> List[str]:
                 res.append(match.group(1))
         res = sorted(set(res))
     except subprocess.TimeoutExpired:
-        logging.info("Can't get Wi-Fi scanning results within %s", str(WIFI_SCAN_TIMEOUT))
+        logging.info("Can't get Wi-Fi scanning results within %d", timeout)
     except subprocess.CalledProcessError as ex:
         logging.info("Error during Wi-Fi scan: %s", ex)
     return res
 
 
-def to_json():
+def to_json(args) -> dict:
     connections = []
     devices = []
 
@@ -67,7 +63,7 @@ def to_json():
         connections = network_manager.get_connections()
         devices = network_manager.get_devices()
 
-    network_interfaces = NetworkInterfacesAdapter.probe()
+    network_interfaces = NetworkInterfacesAdapter.probe(args.interfaces_conf)
     if network_interfaces is not None:
         connections = connections + network_interfaces.get_connections()
 
@@ -75,35 +71,28 @@ def to_json():
 
     switch_cfg = {}
     try:
-        with open(CONNECTION_MANAGER_CONFIG_FILE, encoding="utf-8") as file:
+        with open(args.config, encoding="utf-8") as file:
             switch_cfg = json.load(file)
     except (FileNotFoundError, PermissionError, OSError, json.decoder.JSONDecodeError) as ex:
-        logging.error("Loading %s failed: %s", CONNECTION_MANAGER_CONFIG_FILE, ex)
+        logging.error("Loading %s failed: %s", args.config, ex)
 
-    res = {
+    return {
         "ui": {"connections": connections, "con_switch": switch_cfg},
-        "data": {"ssids": scan_wifi(), "devices": devices},
+        "data": {"ssids": [] if args.no_scan else scan_wifi(args.scan_iface, args.scan_timeout), "devices": devices},
     }
-    json.dump(res, sys.stdout, sort_keys=True, indent=JSON_INDENT_LEVEL)
 
 
-def from_json():
-    try:
-        cfg = json.load(sys.stdin)
-    except ValueError:
-        print("Invalid JSON", file=sys.stdout)
-        sys.exit(1)
-
+def from_json(cfg, args) -> dict:
     connections = cfg["ui"]["connections"]
 
-    network_interfaces = NetworkInterfacesAdapter.probe()
+    network_interfaces = NetworkInterfacesAdapter.probe(args.interfaces_conf)
     if network_interfaces is not None:
-        apply_res = network_interfaces.apply(connections)
+        apply_res = network_interfaces.apply(connections, args.dry_run)
         # NM conflicts with dnsmasq and hostapd
         # Stop them if wlan is not configured in /etc/network/interfaces
-        if not_fully_contains(apply_res.managed_wlans, find_interface_strings("/etc/dnsmasq.conf")):
+        if not_fully_contains(apply_res.managed_wlans, find_interface_strings(args.dnsmasq_conf)):
             os.system("systemctl stop dnsmasq")
-        if not_fully_contains(apply_res.managed_wlans, find_interface_strings("/etc/hostapd.conf")):
+        if not_fully_contains(apply_res.managed_wlans, find_interface_strings(args.hostapd_conf)):
             os.system("systemctl stop hostapd")
         os.system("systemctl restart networking")
 
@@ -113,17 +102,37 @@ def from_json():
     if network_manager is not None:
         # wb-connection-manager will be later restarted by wb-mqtt-confed
         os.system("systemctl stop wb-connection-manager")
-        network_manager.apply(connections)
+        network_manager.apply(connections, args.dry_run)
         # NetworkManager must be restarted to update managed devices
         os.system("systemctl restart NetworkManager")
-    json.dump(cfg["ui"]["con_switch"], sys.stdout, sort_keys=True, indent=JSON_INDENT_LEVEL)
+    return cfg["ui"]["con_switch"]
 
 
-def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "-s":
-        from_json()
+def main() -> None:
+    parser = argparse.ArgumentParser(description="NM helper", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-s", "--save", action="store_true", help="Save configuration")
+    parser.add_argument("-c", "--config", type=str, default="/etc/wb-connection-manager.conf", help="Config file")
+    parser.add_argument("--dnsmasq-conf", type=str, default="/etc/dnsmasq.conf", help="dnsmasq config file")
+    parser.add_argument("--hostapd-conf", type=str, default="/etc/hostapd.conf", help="hostapd config file")
+    parser.add_argument("--interfaces-conf", type=str, default="/etc/network/interfaces", help="interfaces config file")
+    parser.add_argument("--no-scan", action="store_true", help="Don't scan for Wi-Fi networks")
+    parser.add_argument("--scan-iface", type=str, default="wlan0", help="Interface to scan for Wi-Fi networks")
+    parser.add_argument("--scan-timeout", type=int, default=10, help="Scan timeout in seconds")
+    parser.add_argument("--indent", type=int, default=2, help="Indentation level for JSON output")
+    parser.add_argument("--dry-run", action="store_true", help="Don't apply changes")
+    args = parser.parse_args()
+
+    res = None
+    if args.save:
+        try:
+            cfg = json.load(sys.stdin)
+        except ValueError:
+            print("Invalid JSON", file=sys.stdout)
+            sys.exit(1)
+        res = from_json(cfg, args)
     else:
-        to_json()
+        res = to_json(args)
+    json.dump(res, sys.stdout, sort_keys=True, indent=args.indent)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Добавил тесты на `to_json`, `from_json`, используя `python3-dbusmock` для мока
  - Рестарт сервисов через DBus API вместо вызова `systemctl`
  -  Вынес параметры `wb-nm-helper` в аргументы (+увеличен таймаут сканирования):
```sh
# wb-nm-helper -h
usage: wb-nm-helper [-h] [-s] [-c CONFIG] [--dnsmasq-conf DNSMASQ_CONF] [--hostapd-conf HOSTAPD_CONF] [--interfaces-conf INTERFACES_CONF]
                    [--no-scan] [--scan-iface SCAN_IFACE] [--scan-timeout SCAN_TIMEOUT] [--indent INDENT] [--dry-run]

NM helper

optional arguments:
  -h, --help            show this help message and exit
  -s, --save            Save configuration (default: False)
  -c CONFIG, --config CONFIG
                        Config file (default: /etc/wb-connection-manager.conf)
  --dnsmasq-conf DNSMASQ_CONF
                        dnsmasq config file (default: /etc/dnsmasq.conf)
  --hostapd-conf HOSTAPD_CONF
                        hostapd config file (default: /etc/hostapd.conf)
  --interfaces-conf INTERFACES_CONF
                        interfaces config file (default: /etc/network/interfaces)
  --no-scan             Don't scan for Wi-Fi networks (default: False)
  --scan-iface SCAN_IFACE
                        Interface to scan for Wi-Fi networks (default: wlan0)
  --scan-timeout SCAN_TIMEOUT
                        Scan timeout in seconds (default: 10)
  --indent INDENT       Indentation level for JSON output (default: 2)
  --dry-run             Don't apply changes (default: False)
```