### PR TITLE
Add route metric to homeui schema

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.11.1) stable; urgency=medium
+
+  * Add route metric editing to IPv4 DHCP and shared connections
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 22 Dec 2022 11:55:42 +0500
+
 wb-nm-helper (1.11.0) stable; urgency=medium
 
   * Hide connections configured with user.data.read-only=true on UI

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -1086,6 +1086,17 @@
                             "show_editor": true
                         }
                     }
+                },
+                "route-metric": {
+                    "type": "integer",
+                    "title": "Routing metric for default gateway",
+                    "propertyOrder": 15,
+                    "options": {
+                        "show_opt_in": true,
+                        "inputAttributes": {
+                            "placeholder":  " "
+                        }
+                    }
                 }
             },
             "required": ["method"],
@@ -1127,6 +1138,17 @@
                         "show_opt_in": true,
                         "inputAttributes": {
                             "placeholder":  "255.255.255.0"
+                        }
+                    }
+                },
+                "route-metric": {
+                    "type": "integer",
+                    "title": "Routing metric for default gateway",
+                    "propertyOrder": 15,
+                    "options": {
+                        "show_opt_in": true,
+                        "inputAttributes": {
+                            "placeholder":  " "
                         }
                     }
                 }


### PR DESCRIPTION
В схеме редактор для метрики был описан только для статически указанного ip