### PR TITLE
add wb-hide-connection tool to hide and reveal nm-connections in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ successfully requested primary SIM switch in mode
 [user]
 wb.read-only=true
 ```
+Чтобы скрывать соединения в рантайме, можно использовать ```/usr/lib/wb-nm-helper/wb-hide-connection```
 
 ### Доступ в Internet через Wi-Fi AP
 

--- a/bin/wb-hide-connection
+++ b/bin/wb-hide-connection
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 import dbus
 
 from wb.nm_helper.network_manager import NetworkManager

--- a/bin/wb-hide-connection
+++ b/bin/wb-hide-connection
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import sys
+import dbus
+
+from wb.nm_helper.network_manager import NetworkManager
+from wb.nm_helper.network_manager_adapter import DBUSSettings
+
+if len(sys.argv) != 3:
+    sys.exit("Usage:\n%s connection_id wb.read-only_param_value" % sys.argv[0])
+
+con_id, hide_param = sys.argv[1], sys.argv[2]
+
+network_manager = NetworkManager()
+con = network_manager.find_connection(con_id)
+if con:
+    con_settings = DBUSSettings(con.get_settings())
+    con_settings.set_value("user.data", dbus.Dictionary({"wb.read-only" : hide_param}, signature="ss"))
+    con.update_settings(con_settings.params)
+else:
+    sys.exit(1)

--- a/bin/wb-hide-connection
+++ b/bin/wb-hide-connection
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=C0103
 
 import sys
 

--- a/bin/wb-hide-connection
+++ b/bin/wb-hide-connection
@@ -15,7 +15,7 @@ network_manager = NetworkManager()
 con = network_manager.find_connection(con_id)
 if con:
     con_settings = DBUSSettings(con.get_settings())
-    con_settings.set_value("user.data", dbus.Dictionary({"wb.read-only" : hide_param}, signature="ss"))
+    con_settings.set_value("user.data", dbus.Dictionary({"wb.read-only": hide_param}, signature="ss"))
     con.update_settings(con_settings.params)
 else:
     sys.exit(1)

--- a/bin/wb-nm-helper
+++ b/bin/wb-nm-helper
@@ -1,8 +1,22 @@
 #!/usr/bin/env python3
-# pylint: disable=C0103
+# pylint: disable=C0103, W0105
 
+import subprocess
 import sys
+import time
 
 from wb.nm_helper.nm_helper import main
 
-sys.exit(main())
+"""
+wb-hwconf-manager could perform hiding/revealing NM-connections (by modifying their params)
+=> should be active already
+"""
+service_name = "wb-hwconf-manager"
+tries = 30
+
+for _ in range(tries):
+    if subprocess.call("systemctl -q is-active %s" % service_name, shell=True) == 0:
+        sys.exit(main())
+    time.sleep(1)
+
+sys.exit("Service %s is not active after %d queries" % (service_name, tries))

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.22.0) stable; urgency=medium
+
+  * Add "wb-hide-connection" tool to hide and reveal nm-connections in runtime
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 28 Mar 2023 17:36:12 +0600
+
 wb-nm-helper (1.21.0) stable; urgency=medium
 
   * Wi-Fi connections are now also considered sticky
@@ -9,7 +15,7 @@ wb-nm-helper (1.20.0) stable; urgency=medium
   * Add old connections virtual devices auto removing
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 01 Mar 2023 14:39:48 +0300
- 
+
 wb-nm-helper (1.19.1) stable; urgency=medium
 
   * Remove duplicate SSIDs in config editor
@@ -236,7 +242,7 @@ wb-nm-helper (1.0.2) stable; urgency=medium
 
 wb-nm-helper (1.0.1) stable; urgency=medium
 
-  * Hide old web-configurator for /etc/network/interfaces 
+  * Hide old web-configurator for /etc/network/interfaces
   * Fix displaying of Wi-Fi and CAN connections defined in /etc/network/interfaces
   * Fix parsing of /etc/network/interfaces with only comments
   * Disable hostapd and dnsmasq when creating Wi-Fi AP managed by NetworkManager

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-nm-helper (1.22.0) stable; urgency=medium
 
   * Add "wb-hide-connection" tool to hide and reveal nm-connections in runtime
+  * wb-nm-helper: wait for wb-hwconf-manager.service to become active
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 28 Mar 2023 17:36:12 +0600
 

--- a/debian/wb-nm-helper.install
+++ b/debian/wb-nm-helper.install
@@ -1,6 +1,7 @@
 bin/wb-nm-helper /usr/bin
 wb-network.schema.json /usr/share/wb-mqtt-confed/schemas
 bin/wb-connection-manager /usr/lib/wb-connection-manager
+bin/wb-hide-connection /usr/lib/wb-nm-helper
 wb-connection-manager.conf /etc
 bin/disable-if-not-configured.sh /usr/lib/wb-nm-helper
 bin/update-motd.d/50-wb-old-connections /etc/update-motd.d


### PR DESCRIPTION
сделал тулзу, чтобы прятать NM-соединения в рантайме

[дёргаем](https://github.com/wirenboard/wb-hwconf-manager/pull/102) её из hwconf

testing-set на потыкать:
echo "deb http://deb.wirenboard.com/all experimental.hide-gsm-connections main" > /etc/apt/sources.list.d/test-hide-gsm-connections.list