### PR TITLE
hide wb-gsm-sim* connections if modem is not enabled

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.23.0) stable; urgency=medium
+
+  * Hide wb-gsm-sim* connections if modem is not enabled
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 29 Mar 2023 32:12:30 +0400
+
 wb-nm-helper (1.22.0) stable; urgency=medium
 
   * Add support for multiple iface options
@@ -15,7 +21,7 @@ wb-nm-helper (1.20.0) stable; urgency=medium
   * Add old connections virtual devices auto removing
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 01 Mar 2023 14:39:48 +0300
- 
+
 wb-nm-helper (1.19.1) stable; urgency=medium
 
   * Remove duplicate SSIDs in config editor
@@ -242,7 +248,7 @@ wb-nm-helper (1.0.2) stable; urgency=medium
 
 wb-nm-helper (1.0.1) stable; urgency=medium
 
-  * Hide old web-configurator for /etc/network/interfaces 
+  * Hide old web-configurator for /etc/network/interfaces
   * Fix displaying of Wi-Fi and CAN connections defined in /etc/network/interfaces
   * Fix parsing of /etc/network/interfaces with only comments
   * Disable hostapd and dnsmasq when creating Wi-Fi AP managed by NetworkManager

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import subprocess
+from unittest.mock import Mock
 
 import dbus
 import dbusmock
@@ -12,7 +13,7 @@ from dbusmock.templates.networkmanager import (
     DeviceState,
 )
 
-from wb.nm_helper.nm_helper import from_json, to_json
+from wb.nm_helper import nm_helper
 
 
 class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
@@ -181,6 +182,8 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
     def test_to_json(self):
         # pylint: disable=R0915
 
+        nm_helper.is_modem_enabled = Mock(return_value=True)
+
         self.networkmanager_mock.AddEthernetDevice("mock_eth0", "eth0", DeviceState.ACTIVATED)
         self.networkmanager_mock.AddEthernetDevice("mock_eth1", "eth1", DeviceState.ACTIVATED)
         self.networkmanager_mock.AddWiFiDevice("mock_wlan0", "wlan0", DeviceState.ACTIVATED)
@@ -192,7 +195,7 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         self.add_wb_gsm_sim2()
         self.add_wb_ap()
 
-        res = to_json(
+        res = nm_helper.to_json(
             args=argparse.Namespace(
                 config="tests/data/wb-connection-manager.conf",
                 interfaces_conf="tests/data/interfaces",
@@ -293,7 +296,7 @@ def test_from_json():
     with open("tests/data/ui.json", "r", encoding="utf-8") as f:
         cfg = json.load(f)
 
-    res = from_json(
+    res = nm_helper.from_json(
         cfg,
         args=argparse.Namespace(
             interfaces_conf="tests/data/interfaces",


### PR DESCRIPTION
по результатам последнего обсуждения скрытия модемных соединений, решили отказаться от хуков wb-hwconf-manager (из-за краевого случая, выстреливающего при обновлении fit-ом) и фильтровать список соединений на этапе отдачи webui

=> не нужны изменения в wb-configs и wb-hwconf-manager

при очистке /etc/NetworkManager/system_connections/ всё работает