### PR TITLE
virtual-devices: disable state polling if NetworkManager is not running

### DIFF
--- a/bin/connections_virtual_devices.js
+++ b/bin/connections_virtual_devices.js
@@ -16,6 +16,7 @@ var deviceMetaTopicList = ['name', 'driver'];
 var updateNetworkTimer = null;
 var pollingEnabled = false;
 
+
 function getVirtualDeviceName(connectionUuid) {
   return 'system__networks__' + connectionUuid;
 }

--- a/bin/connections_virtual_devices.js
+++ b/bin/connections_virtual_devices.js
@@ -305,7 +305,7 @@ function updateDevices() {
 }
 
 function startPollingIfNetworkManagerIsUp() {
-  runShellCommand('LC_ALL=C nmcli g 2>/dev/null', {
+  runShellCommand('systemctl is-active NetworkManager.service >/dev/null', {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
       if (exitCode == 0 && updateNetworkTimer === null) {

--- a/bin/connections_virtual_devices.js
+++ b/bin/connections_virtual_devices.js
@@ -16,7 +16,6 @@ var deviceMetaTopicList = ['name', 'driver'];
 var updateNetworkTimer = null;
 var pollingEnabled = false;
 
-
 function getVirtualDeviceName(connectionUuid) {
   return 'system__networks__' + connectionUuid;
 }
@@ -309,10 +308,12 @@ function startPollingIfNetworkManagerIsUp() {
   runShellCommand('systemctl is-active NetworkManager.service >/dev/null', {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      if (exitCode == 0 && updateNetworkTimer === null) {
-        log("NetworkManager is up, start polling");
-        pollingEnabled = true;
-        updateNetworkTimer = setInterval(updateDevices, 2000);
+      if (exitCode == 0) {
+        if (updateNetworkTimer === null) {
+          log("NetworkManager is up, start polling");
+          pollingEnabled = true;
+          updateNetworkTimer = setInterval(updateDevices, 2000);
+        }
       } else {
         if (updateNetworkTimer !== null) {
           log("NetworkManager is down, stop polling");

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.23.1-wb101) stable; urgency=medium
+
+  * virtual-devices: disable state polling if NetworkManager is not running
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 17 Apr 2023 15:50:28 +0600
+
 wb-nm-helper (1.23.1-wb100) stable; urgency=medium
 
   * Revert "Don't restart NetworkManager service if not required (#59)"


### PR DESCRIPTION
Если в системе принудительно выключить NetworkManager (что некоторые делают), скрипт `connections_virtual_devices.js` начинает неистово наваливать записей в логи.

Починил это, и в принципе сделал так, чтобы опрос не включался, если NetworkManager выключен.