### PR TITLE
Feature/60576 modem tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.0) stable; urgency=medium
+
+  * Get wb-internal modem via specific tag
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 05 May 2023 11:45:12 +0400
+
 wb-nm-helper (1.26.0) stable; urgency=medium
 
   * Add wifi encryption algorithm configuration

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Depends: ${misc:Depends},
          network-manager,
          modemmanager,
          mobile-broadband-provider-info,
-         wb-configs (>= 3.15.4~~),
+         wb-configs (>= 3.16.0~~),
          nftables,
          ifmetric
 Description:  Wirenboard network configuration backend for wb-mqtt-confed.

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Depends: ${misc:Depends},
          network-manager,
          modemmanager,
          mobile-broadband-provider-info,
-         wb-configs (>= 3.4.0),
+         wb-configs (>= 3.15.4~~),
          nftables,
          ifmetric
 Description:  Wirenboard network configuration backend for wb-mqtt-confed.

--- a/tests/mm_mock.py
+++ b/tests/mm_mock.py
@@ -386,11 +386,17 @@ class FakeModemManager(IModemManager):
     def __init__(self, net_man):
         self.net_man = net_man
 
-    def get_primary_sim_slot(self, modem_path):
+    @property
+    def default_modem_path(self):
+        return "/fake/Devices/ttyUSB1/2"
+
+    def get_primary_sim_slot(self, modem_path=None):
+        modem_path = modem_path or self.default_modem_path
         dev_name = modem_path.split("/")[3]
         return self.net_man.devices.get(dev_name).get("sim_slot")
 
-    def set_primary_sim_slot(self, modem_path, slot_index):
+    def set_primary_sim_slot(self, slot_index, modem_path=None):
+        modem_path = modem_path or self.default_modem_path
         dev_name = modem_path.split("/")[3]
         device = FakeNMDevice(dev_name, self.net_man)
         for data in self.net_man.connections.values():
@@ -406,5 +412,5 @@ class FakeModemManager(IModemManager):
                 return True
         return False
 
-    def get_modem(self, modem_path):
+    def get_modem(self, modem_path=None):
         pass

--- a/tests/mm_mock.py
+++ b/tests/mm_mock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import namedtuple
 from typing import List, Optional
 
 from wb.nm_helper.modem_manager_interfaces import IModemManager
@@ -385,18 +386,19 @@ class FakeNetworkManager(INetworkManager):  # pylint: disable=too-many-public-me
 class FakeModemManager(IModemManager):
     def __init__(self, net_man):
         self.net_man = net_man
+        self.fake_modem_path = "/fake/Devices/ttyUSB1/2"
 
     @property
-    def default_modem_path(self):
-        return "/fake/Devices/ttyUSB1/2"
+    def wb_specific_property(self):
+        return namedtuple("device_property", "prop_name prop_value")(prop_name="Device", prop_value="wbc")
 
     def get_primary_sim_slot(self, modem_path=None):
-        modem_path = modem_path or self.default_modem_path
+        modem_path = modem_path or self.fake_modem_path
         dev_name = modem_path.split("/")[3]
         return self.net_man.devices.get(dev_name).get("sim_slot")
 
     def set_primary_sim_slot(self, slot_index, modem_path=None):
-        modem_path = modem_path or self.default_modem_path
+        modem_path = modem_path or self.fake_modem_path
         dev_name = modem_path.split("/")[3]
         device = FakeNMDevice(dev_name, self.net_man)
         for data in self.net_man.connections.values():
@@ -414,3 +416,8 @@ class FakeModemManager(IModemManager):
 
     def get_modem(self, modem_path=None):
         pass
+
+    def get_modem_prop(self, modem_iface, propname):
+        if propname == self.wb_specific_property.prop_name:
+            return self.wb_specific_property.prop_value
+        return None

--- a/wb/nm_helper/modem_manager.py
+++ b/wb/nm_helper/modem_manager.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import dbus
 
 from wb.nm_helper.modem_manager_interfaces import IModemManager
@@ -9,30 +11,44 @@ class ModemManager(IModemManager):
         self.mm_proxy = self.bus.get_object("org.freedesktop.ModemManager1", "/org/freedesktop/ModemManager1")
 
     @property
-    def default_modem_path(self):
-        return "/org/freedesktop/ModemManager1/Modem/wbc"
+    def wb_specific_property(self):
+        return namedtuple("device_property", "prop_name prop_value")(prop_name="Device", prop_value="wbc")
 
-    def get_modem(self, modem_path=None):
-        modem_path = modem_path or self.default_modem_path
+    def _get_modem_iface(self, modem_path):
+        modem_proxy = self.bus.get_object("org.freedesktop.ModemManager1", modem_path)
+        return dbus.Interface(modem_proxy, "org.freedesktop.ModemManager1.Modem")
+
+    def _get_modem_by_path(self, modem_path):
         objects = dbus.Interface(self.mm_proxy, "org.freedesktop.DBus.ObjectManager")
         for obj in objects.GetManagedObjects():
             if obj == modem_path:
-                modem_proxy = self.bus.get_object("org.freedesktop.ModemManager1", obj)
-                modem = dbus.Interface(modem_proxy, "org.freedesktop.ModemManager1.Modem")
+                return self._get_modem_iface(obj)
+        return None
+
+    def _get_modem_by_default_prop(self):
+        objects = dbus.Interface(self.mm_proxy, "org.freedesktop.DBus.ObjectManager")
+        for obj in objects.GetManagedObjects():
+            modem = self._get_modem_iface(obj)
+            if self.get_modem_prop(modem, "Device") == "wbc":
                 return modem
         return None
 
+    def get_modem_prop(self, modem_iface, propname):
+        modem_properties = dbus.Interface(modem_iface, "org.freedesktop.DBus.Properties")
+        return modem_properties.Get("org.freedesktop.ModemManager1.Modem", propname)
+
+    def get_modem(self, modem_path=None):
+        if modem_path:
+            return self._get_modem_by_path(modem_path)
+        return self._get_modem_by_default_prop()
+
     def get_primary_sim_slot(self, modem_path=None):
-        modem_path = modem_path or self.default_modem_path
         modem = self.get_modem(modem_path)
         if modem:
-            modem_properties = dbus.Interface(modem, "org.freedesktop.DBus.Properties")
-            current_sim = modem_properties.Get("org.freedesktop.ModemManager1.Modem", "PrimarySimSlot")
-            return current_sim
+            return self.get_modem_prop(modem, "PrimarySimSlot")
         return None
 
     def set_primary_sim_slot(self, slot_index, modem_path=None):
-        modem_path = modem_path or self.default_modem_path
         modem = self.get_modem(modem_path)
         if modem:
             modem.SetPrimarySimSlot(slot_index)

--- a/wb/nm_helper/modem_manager.py
+++ b/wb/nm_helper/modem_manager.py
@@ -8,7 +8,12 @@ class ModemManager(IModemManager):
         self.bus = dbus.SystemBus()
         self.mm_proxy = self.bus.get_object("org.freedesktop.ModemManager1", "/org/freedesktop/ModemManager1")
 
-    def get_modem(self, modem_path):
+    @property
+    def default_modem_path(self):
+        return "/org/freedesktop/ModemManager1/Modem/wbc"
+
+    def get_modem(self, modem_path=None):
+        modem_path = modem_path or self.default_modem_path
         objects = dbus.Interface(self.mm_proxy, "org.freedesktop.DBus.ObjectManager")
         for obj in objects.GetManagedObjects():
             if obj == modem_path:
@@ -17,7 +22,8 @@ class ModemManager(IModemManager):
                 return modem
         return None
 
-    def get_primary_sim_slot(self, modem_path):
+    def get_primary_sim_slot(self, modem_path=None):
+        modem_path = modem_path or self.default_modem_path
         modem = self.get_modem(modem_path)
         if modem:
             modem_properties = dbus.Interface(modem, "org.freedesktop.DBus.Properties")
@@ -25,7 +31,8 @@ class ModemManager(IModemManager):
             return current_sim
         return None
 
-    def set_primary_sim_slot(self, modem_path, slot_index):
+    def set_primary_sim_slot(self, slot_index, modem_path=None):
+        modem_path = modem_path or self.default_modem_path
         modem = self.get_modem(modem_path)
         if modem:
             modem.SetPrimarySimSlot(slot_index)

--- a/wb/nm_helper/modem_manager_interfaces.py
+++ b/wb/nm_helper/modem_manager_interfaces.py
@@ -2,14 +2,19 @@ from abc import ABC, abstractmethod
 
 
 class IModemManager(ABC):
+    @property
     @abstractmethod
-    def get_modem(self, modem_path):
+    def default_modem_path(self):
         pass
 
     @abstractmethod
-    def get_primary_sim_slot(self, modem_path):
+    def get_modem(self, modem_path=None):
         pass
 
     @abstractmethod
-    def set_primary_sim_slot(self, modem_path, slot_index):
+    def get_primary_sim_slot(self, modem_path=None):
+        pass
+
+    @abstractmethod
+    def set_primary_sim_slot(self, slot_index, modem_path=None):
         pass

--- a/wb/nm_helper/modem_manager_interfaces.py
+++ b/wb/nm_helper/modem_manager_interfaces.py
@@ -4,7 +4,11 @@ from abc import ABC, abstractmethod
 class IModemManager(ABC):
     @property
     @abstractmethod
-    def default_modem_path(self):
+    def wb_specific_property(self):
+        pass
+
+    @abstractmethod
+    def get_modem_prop(self, modem_iface, propname):
         pass
 
     @abstractmethod


### PR DESCRIPTION
прописали нашему модему специальный тег через [udev](https://github.com/wirenboard/wb-configs/pull/118)

берём в переключалке модем по этому тегу (**под капотом тег добавляет модему property "Device"**; dbus-path не меняется, на самом деле)

напаял наш 4g-модем на юсб-провод; воткнул в вб; включил; убедился, что основному wbc-модему не мешает