### PR TITLE
Fix unnecessary NetworkManager restarting

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.1) stable; urgency=medium
+
+  * Fix unnecessary NetworkManager restarting after connection deletion
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 20 Jun 2023 17:03:11 +0500
+
 wb-nm-helper (1.27.0) stable; urgency=medium
 
   * Change SIM slot change method

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -6,7 +6,6 @@ from wb.nm_helper.network_manager_adapter import (
     JSONSettings,
     ModemConnection,
     WiFiAp,
-    serialize_dbus_obj,
 )
 
 
@@ -289,46 +288,3 @@ def test_modem_set_dbus_options(json, dbus_old, dbus_new):
     dbus_new_settings = DBUSSettings(dbus_new)
     access_point.set_dbus_options(dbus_old_settings, json_settings)
     assert dbus_old_settings.params == dbus_new_settings.params
-
-
-# dbus-types: https://dbus.freedesktop.org/doc/dbus-python/tutorial.html#basic-types
-@pytest.mark.parametrize(
-    "dbus_obj,serialized",
-    [
-        (dbus.Boolean(True), "1"),
-        (dbus.Byte(b"B"), str(ord("B"))),
-        (dbus.Int16(123), "123"),
-        (dbus.UInt16(123), "123"),
-        (dbus.Int32(123), "123"),
-        (dbus.UInt32(123), "123"),
-        (dbus.Int64(123), "123"),
-        (dbus.UInt64(123), "123"),
-        (dbus.Double(123.456), "123.456"),
-        (dbus.ObjectPath("/test/1/2/3"), '"/test/1/2/3"'),
-        (dbus.Signature("sv"), '"sv"'),
-        (dbus.String("test string"), '"test string"'),
-        (dbus.ByteArray(b"test string"), '"test string"'),
-        (dbus.Struct((123, 123.456, "test string")), '[123, 123.456, "test string"]'),
-        (
-            dbus.Struct((123, 123.456, "test string", dbus.Struct((789, dbus.String("test"))))),
-            '[123, 123.456, "test string", [789, "test"]]',
-        ),
-        (
-            dbus.Dictionary(
-                {
-                    dbus.String("test dict"): dbus.Dictionary(
-                        {
-                            dbus.String("boolean"): dbus.Boolean(False),
-                            dbus.String("bytearray"): dbus.ByteArray(b"test bytearray"),
-                            dbus.String("float"): dbus.Double(123.456),
-                            dbus.String("int"): dbus.Int32(123),
-                        }
-                    )
-                }
-            ),
-            '{"test dict": {"boolean": 0, "bytearray": "test bytearray", "float": 123.456, "int": 123}}',
-        ),
-    ],
-)
-def test_dbus_obj_serialization(dbus_obj, serialized):
-    assert serialize_dbus_obj(dbus_obj) == serialized

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -11,11 +11,7 @@ from typing import List, TypedDict
 
 import dbus
 
-from .network_management_system import (
-    DEVICE_TYPE_ETHERNET,
-    DEVICE_TYPE_MODEM,
-    DEVICE_TYPE_WIFI,
-)
+from .network_management_system import DEVICE_TYPE_ETHERNET, DEVICE_TYPE_MODEM, DEVICE_TYPE_WIFI
 from .network_manager import (
     NM_DEVICE_TYPE_ETHERNET,
     NM_DEVICE_TYPE_MODEM,
@@ -167,15 +163,8 @@ def scan(dev: NMWirelessDevice, scan_timeout: datetime.timedelta) -> None:
     return res
 
 
-class DbusJSONEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, (dbus.Byte, dbus.ByteArray)):
-            return o.decode("utf-8")
-        return super().default(o)
-
-
-def serialize_dbus_obj(dbus_obj) -> str:
-    return json.dumps(dbus_obj, sort_keys=True, cls=DbusJSONEncoder)
+def serialize_json_obj(obj) -> str:
+    return json.dumps(obj, sort_keys=True)
 
 
 class JSONSettings:
@@ -454,14 +443,16 @@ def apply(iface, c_handler, network_manager: NetworkManager, dry_run: bool) -> b
         return False
     if json_settings.get_opt("connection.uuid"):
         for con in network_manager.get_connections():
-            old_settings = con.get_settings()
-            dbus_settings = DBUSSettings(old_settings)
+            dbus_settings = DBUSSettings(con.get_settings())
             if dbus_settings.get_opt("connection.uuid") == json_settings.get_opt("connection.uuid"):
                 if dbus_settings.get_opt("connection.id") == json_settings.get_opt("connection.id"):
+                    old_dump = serialize_json_obj(iface)
+                    new_dump = serialize_json_obj(c_handler.get_connection(con))
+                    if old_dump == new_dump:
+                        return False
                     c_handler.set_dbus_options(dbus_settings, json_settings)
                     con.update_settings(dbus_settings.params)
-                    settings = con.get_settings()
-                    return serialize_dbus_obj(old_settings) != serialize_dbus_obj(settings)
+                    return True
                 con.delete()
                 network_manager.add_connection(c_handler.create(json_settings))
                 return False

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -11,7 +11,11 @@ from typing import List, TypedDict
 
 import dbus
 
-from .network_management_system import DEVICE_TYPE_ETHERNET, DEVICE_TYPE_MODEM, DEVICE_TYPE_WIFI
+from .network_management_system import (
+    DEVICE_TYPE_ETHERNET,
+    DEVICE_TYPE_MODEM,
+    DEVICE_TYPE_WIFI,
+)
 from .network_manager import (
     NM_DEVICE_TYPE_ETHERNET,
     NM_DEVICE_TYPE_MODEM,


### PR DESCRIPTION
Check connection changes by editable settings not by those got from DBus. Settings from DBus can be incomplete and contain different types

Факт того, что настройки соединения не изменились, проверялся сравнением настроек соединения, которые были считаны из DBus до применения изменений и после. Эти настройки содержат не все изменения и могут иметь разные типы данных.

Например, было:
```json
{
  "802-11-wireless": {
    "mac-address-blacklist": [],
    "mode": "ap",
    "powersave": 2,
    "security": "802-11-wireless-security",
    "seen-bssids": [
      "F0:C8:14:48:D3:97"
    ],
    "ssid": "WirenBoard-APT6KWYK"
  },
  "802-11-wireless-security": {
    "key-mgmt": "wpa-psk",
    "psk": "12345678",
    "wps-method": 1
  },
  "connection": {
    "autoconnect": true,
    "id": "wb-ap",
    "interface-name": "wlan0",
    "permissions": [],
    "timestamp": 1687260260,
    "type": "802-11-wireless",
    "uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885"
  },
  "ipv4": {
    "address-data": [
      {
        "address": "192.168.42.1",
        "prefix": 24
      }
    ],
    "method": "shared",
    "route-data": [],
    "routes": []
  },
  "ipv6": {
    "address-data": [],
    "addresses": [],
    "dns-search": [],
    "method": "ignore",
    "route-data": [],
    "routes": []
  },
  "proxy": {},
  "user": {
    "data": {
      "wb.disable-nat": "false"
    }
  }
}
```

Стало:
```json
{
  "802-11-wireless": {
    "mac-address-blacklist": [],
    "mode": "ap",
    "powersave": 2,
    "security": "802-11-wireless-security",
    "seen-bssids": [
      "F0:C8:14:48:D3:97"
    ],
    "ssid": [
      87,
      105,
      114,
      101,
      110,
      66,
      111,
      97,
      114,
      100,
      45,
      65,
      80,
      84,
      54,
      75,
      87,
      89,
      75
    ]
  },
  "802-11-wireless-security": {
    "key-mgmt": "wpa-psk",
    "wps-method": 1
  },
  "connection": {
    "id": "wb-ap",
    "interface-name": "wlan0",
    "permissions": [],
    "timestamp": 1687260260,
    "type": "802-11-wireless",
    "uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885"
  },
  "ipv4": {
    "address-data": [
      {
        "address": "192.168.42.1",
        "prefix": 24
      }
    ],
    "addresses": [
      [
        19572928,
        24,
        0
      ]
    ],
    "dns-search": [],
    "method": "shared",
    "route-data": [],
    "routes": []
  },
  "ipv6": {
    "address-data": [],
    "addresses": [],
    "dns-search": [],
    "method": "ignore",
    "route-data": [],
    "routes": []
  },
  "proxy": {},
  "user": {
    "data": {
      "wb.disable-nat": "false"
    }
  }
}
```

По факту никаких изменений настроек не было, но NM всё равно перезапустили.
Теперь сравниваются те настройки, которые может изменить пользователь через интерфейс.