### PR TITLE
Fix logging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.4) stable; urgency=medium
+
+  * Fix logging
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 28 Jun 2023 17:11:00 +0400
+
 wb-nm-helper (1.27.3) stable; urgency=medium
 
   * Fix bug disabling Wi-Fi AP

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -280,7 +280,7 @@ def check_connectivity(active_cn: NMActiveConnection, config: ConfigFile = None)
         config = ConfigFile()
         config.load_config(read_config_json())
     ifaces = active_cn.get_ifaces()
-    logging.debug("interfaces for %s: %s", active_cn.get_connection_id(), ifaces)
+    logging.debug("interfaces for %s: %s", active_cn.get_connection_id(), ", ".join([str(i) for i in ifaces]))
     if ifaces and ifaces[0]:
         try:
             payload = curl_get(ifaces[0], config.connectivity_check_url)


### PR DESCRIPTION
Before:
```sh
$ journalctl -u wb-connection-manager
...
Jun 29 12:10:28 wirenboard-A7PWH4NX wb-connection-manager[15318]: interfaces for Beeline_2.4G_0a64: [dbus.String('wlan1', variant_level=1)]
```

After:
```sh
$ journalctl -u wb-connection-manager
...
Jun 29 13:30:06 wirenboard-A7PWH4NX wb-connection-manager[8262]: interfaces for Beeline_2.4G_0a64: wlan1
```