### PR TITLE
Do not restart NetworkManager on connection settings change

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.5) stable; urgency=medium
+
+  * Do not restart NetworkManager on connection settings change
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 12 Jul 2023 17:40:24 +0500
+
 wb-nm-helper (1.27.4) stable; urgency=medium
 
   * Fix logging

--- a/wb/nm_helper/network_manager.py
+++ b/wb/nm_helper/network_manager.py
@@ -145,8 +145,13 @@ class NetworkManager(NMObject, INetworkManager):
         settings.AddConnection(connection_settings)
 
     def activate_connection(self, con: NMConnection, dev: NMDevice) -> NMActiveConnection:
+        dev_obj = (
+            dev.get_object()
+            if dev is not None
+            else self.bus.get_object("org.freedesktop.NetworkManager", "/")
+        )
         return NMActiveConnection(
-            self.get_iface().ActivateConnection(con.get_object(), dev.get_object(), "/"),
+            self.get_iface().ActivateConnection(con.get_object(), dev_obj, "/"),
             self.bus,
         )
 


### PR DESCRIPTION
При изменении настроек соединения перезапускался NM. В результате перезапускались все соединения. Фронтенд часто не получал сообщение с результатом выполнения RPC.
Сделал, чтобы для неактивных соединений просто менялись настройки. NM с переключалкой потом решают, что делать.
Активное соединение разрывается, меняются настройки и производится попытка переподнять его. 