### PR TITLE
Fix connectivity checking

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.5) stable; urgency=medium
+
+  * Fix connectivity checking
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 14 Jul 2023 10:37:40 +0500
+
 wb-nm-helper (1.27.4) stable; urgency=medium
 
   * Fix logging

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends: debhelper (>= 10),
                python3-jsonschema,
                python3-pyparsing,
                python3-pycurl,
+               python3-pycares,
                python3-wb-common (>= 2.1.1)
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-nm-helper

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -685,14 +685,14 @@ class SingleFunctionTests(TestCase):
             [call(level=logging.INFO, format=connection_manager.LOGGING_FORMAT)], mock_basic_config.mock_calls
         )
 
-    def test_replace_host_name_by_ip(self):
+    def test_replace_host_name_with_ip(self):
         def dsn_resolver_mock(url, iface):
             if iface == "wlan1":
                 return url
             return "1.1.1.1"
 
         self.assertEqual(
-            "bad_url", connection_manager.replace_host_name_by_ip("bad_url", "wlan1", dsn_resolver_mock)
+            "bad_url", connection_manager.replace_host_name_with_ip("bad_url", "wlan1", dsn_resolver_mock)
         )
         self.assertEqual(
             "http://1.1.1.1/params/some",

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -63,6 +63,7 @@ class DummyCurl:
     URL = 10001
     WRITEDATA = 10002
     INTERFACE = 10003
+    HTTPHEADER = 10023
 
 
 class DummyBytesIO:
@@ -547,7 +548,7 @@ class SingleFunctionTests(TestCase):
         DummyBytesIO.getvalue = MagicMock(return_value="ЖЖЖ".encode("UTF8"))
         with patch.object(pycurl, "Curl", DummyCurl), patch.object(io, "BytesIO", DummyBytesIO):
             output = connection_manager.curl_get("dummy_if", "dummy_url")
-            self.assertEqual(5, DummyCurl.setopt.call_count)
+            self.assertEqual(6, DummyCurl.setopt.call_count)
             self.assertEqual(call(pycurl.Curl.URL, "dummy_url"), DummyCurl.setopt.mock_calls[0])
             self.assertEqual(2, len(DummyCurl.setopt.mock_calls[1].args))
             self.assertEqual(pycurl.Curl.WRITEDATA, DummyCurl.setopt.mock_calls[1].args[0])
@@ -560,6 +561,10 @@ class SingleFunctionTests(TestCase):
             self.assertEqual(
                 call(pycurl.TIMEOUT, connection_manager.CONNECTIVITY_CHECK_TIMEOUT),
                 DummyCurl.setopt.mock_calls[4],
+            )
+            self.assertEqual(
+                call(pycurl.Curl.HTTPHEADER, ["Host: dummy_url"]),
+                DummyCurl.setopt.mock_calls[5],
             )
             self.assertEqual([call()], DummyCurl.perform.mock_calls)
             self.assertEqual([call()], DummyCurl.close.mock_calls)

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -696,13 +696,13 @@ class SingleFunctionTests(TestCase):
         )
         self.assertEqual(
             "http://1.1.1.1/params/some",
-            connection_manager.replace_host_name_by_ip(
+            connection_manager.replace_host_name_with_ip(
                 "http://good_url.com/params/some", "wlan2", dsn_resolver_mock
             ),
         )
         self.assertEqual(
             "http://1.1.1.1:8080/params/some",
-            connection_manager.replace_host_name_by_ip(
+            connection_manager.replace_host_name_with_ip(
                 "http://good_url.com:8080/params/some", "wlan2", dsn_resolver_mock
             ),
         )

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -543,7 +543,7 @@ class SingleFunctionTests(TestCase):
                 self.assertEqual(1, mock_load.call_count)
 
     def test_curl_get(self):
-        def dns_resolver_mock(url, iface):
+        def dns_resolver_mock(url, _iface):
             return url
 
         DummyCurl.setopt = MagicMock()

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -543,9 +543,7 @@ class SingleFunctionTests(TestCase):
                 self.assertEqual(1, mock_load.call_count)
 
     def test_curl_get(self):
-        def dns_resolver_mock(url, _iface):
-            return url
-
+        dns_resolver_mock = MagicMock()
         DummyCurl.setopt = MagicMock()
         DummyCurl.perform = MagicMock()
         DummyCurl.close = MagicMock()
@@ -686,14 +684,14 @@ class SingleFunctionTests(TestCase):
         )
 
     def test_replace_host_name_with_ip(self):
-        def dsn_resolver_mock(url, iface):
-            if iface == "wlan1":
-                return url
-            return "1.1.1.1"
+        dsn_resolver_mock = MagicMock()
 
+        dsn_resolver_mock.return_value = "bad_url"
         self.assertEqual(
             "bad_url", connection_manager.replace_host_name_with_ip("bad_url", "wlan1", dsn_resolver_mock)
         )
+
+        dsn_resolver_mock.return_value = "1.1.1.1"
         self.assertEqual(
             "http://1.1.1.1/params/some",
             connection_manager.replace_host_name_with_ip(
@@ -705,6 +703,14 @@ class SingleFunctionTests(TestCase):
             connection_manager.replace_host_name_with_ip(
                 "http://good_url.com:8080/params/some", "wlan2", dsn_resolver_mock
             ),
+        )
+
+        self.assertEqual(
+            [
+                call("good_url.com", "wlan2"),
+                call("good_url.com", "wlan2"),
+            ],
+            dsn_resolver_mock.mock_calls,
         )
 
 

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -2,17 +2,17 @@ import datetime
 import io
 import json
 import logging
+import select
 import signal
+import socket
 import subprocess
 import sys
 import time
-import pycares
-import select
-import socket
-from urllib.parse import urlparse, urlunparse
 from typing import Dict, Iterator, List, Optional
+from urllib.parse import urlparse, urlunparse
 
 import dbus
+import pycares
 import pycurl
 from dbus import DBusException
 

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -268,17 +268,18 @@ def wait_pycares_channel(channel):
         if not read_fds and not write_fds:
             break
         timeout = channel.timeout()
+        no_file_d = pycares.ARES_SOCKET_BAD  # pylint: disable=E1101
         if not timeout:
-            channel.process_fd(pycares.ARES_SOCKET_BAD, pycares.ARES_SOCKET_BAD)
+            channel.process_fd(no_file_d, no_file_d)
             continue
-        rlist, wlist, xlist = select.select(read_fds, write_fds, [], timeout)
-        for fd in rlist:
-            channel.process_fd(fd, pycares.ARES_SOCKET_BAD)
-        for fd in wlist:
-            channel.process_fd(pycares.ARES_SOCKET_BAD, fd)
+        rlist, wlist, _xlist = select.select(read_fds, write_fds, [], timeout)
+        for file_d in rlist:
+            channel.process_fd(file_d, no_file_d)
+        for file_d in wlist:
+            channel.process_fd(no_file_d, file_d)
 
 
-class PycaresCallback:
+class PycaresCallback:  # pylint: disable=R0903
     def __init__(self) -> None:
         self.result = None
         self.error = None

--- a/wb/nm_helper/dns_resolver.py
+++ b/wb/nm_helper/dns_resolver.py
@@ -1,0 +1,55 @@
+import select
+import socket
+import time
+
+import pycares
+
+
+# Taken from https://github.com/saghul/pycares/blob/master/examples/cares-select.py
+def wait_pycares_channel(channel: pycares.Channel) -> None:
+    start = time.monotonic_ns()
+    while time.monotonic_ns() - start < 5000000000:
+        read_fds, write_fds = channel.getsock()
+        if not read_fds and not write_fds:
+            break
+        timeout = channel.timeout()
+        no_file_d = pycares.ARES_SOCKET_BAD  # pylint: disable=E1101
+        if not timeout:
+            channel.process_fd(no_file_d, no_file_d)
+            continue
+        rlist, wlist, _xlist = select.select(read_fds, write_fds, [], timeout)
+        for file_d in rlist:
+            channel.process_fd(file_d, no_file_d)
+        for file_d in wlist:
+            channel.process_fd(no_file_d, file_d)
+
+
+class DomainNameResolveException(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+
+class PycaresCallback:  # pylint: disable=R0903
+    def __init__(self) -> None:
+        self.result = None
+        self.error = None
+
+    def __call__(self, result, error) -> None:
+        self.result = result
+        self.error = error
+
+
+def resolve_domain_name(name: str, iface: str) -> str:
+    channel = pycares.Channel()
+    channel.set_local_dev(iface.encode())
+    callback = PycaresCallback()
+    channel.gethostbyname(name, socket.AF_INET, callback)
+    wait_pycares_channel(channel)
+    if callback.error is None and callback.result is not None and len(callback.result.addresses) > 0:
+        return callback.result.addresses[0]
+    raise DomainNameResolveException(
+        "Error during {} resolving: {}".format(name, "timeout" if callback.error is None else callback.error)
+    )

--- a/wb/nm_helper/dns_resolver.py
+++ b/wb/nm_helper/dns_resolver.py
@@ -25,11 +25,7 @@ def wait_pycares_channel(channel: pycares.Channel) -> None:
 
 
 class DomainNameResolveException(Exception):
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __repr__(self):
-        return self.msg
+    pass
 
 
 class PycaresCallback:  # pylint: disable=R0903


### PR DESCRIPTION
If default route loses connectivity, all DNS requests will fail. Connectivity checking for new connections will also fail even if they have access to Internet. So custom domain name resolving bound to checked interface is added