### PR TITLE
Feature/61776 recheck missing devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.5) stable; urgency=medium
+
+  * Better device presense detection
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 18 Jul 2023 15:35:00 +0600
+
 wb-nm-helper (1.27.4) stable; urgency=medium
 
   * Fix logging

--- a/debian/changelog
+++ b/debian/changelog
@@ -53,7 +53,6 @@ wb-nm-helper (1.27.5) stable; urgency=medium
   * Do not restart NetworkManager on connection settings change
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 12 Jul 2023 17:40:24 +0500
->>>>>>> origin/main
 
 wb-nm-helper (1.27.4) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-nm-helper (1.27.5) stable; urgency=medium
 
   * Better device presense detection
+  * Fixed unneeded GSM connections disconnection
 
  -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 18 Jul 2023 15:35:00 +0600
 

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -31,7 +31,9 @@ class DummyNetworkManager:
 
 
 class DummyNMDevice:
-    pass
+    def __init__(self):
+        self.get_path = MagicMock()
+        self.get_property = MagicMock()
 
 
 class DummyNMConnection:
@@ -411,7 +413,7 @@ class NetworkAwareConfigFileTests(TestCase):
         self.config.network_manager.find_device_for_connection = MagicMock(
             side_effect=[None, test_dev, test_dev, test_dev]
         )
-        test_dev.get_property = MagicMock(side_effect=[True, "dev2", 1, "dev3", "dummy", "dev4"])
+        test_dev.get_property.side_effect = [True, "dev2", 1, "dev3", "dummy", "dev4"]
 
         value1 = self.config.is_connection_unmanaged(test_con)  # no device will be returned
         value2 = self.config.is_connection_unmanaged(test_con)  # True will be returned for managed
@@ -494,7 +496,7 @@ class TimeoutManagerTests(TestCase):
         test_con = DummyNMConnection("dummy", {})
         test_con.get_connection_type = MagicMock(side_effect=["CT1", "CT2", "CT3"])
         test_dev = DummyNMDevice()
-        test_dev.get_property = MagicMock(side_effect=["DEV2", "DEV3"])
+        test_dev.get_property.side_effect = ["DEV2", "DEV3"]
         self.timeout_man.config.network_manager.find_device_for_connection = MagicMock(return_value=test_dev)
         self.timeout_man.device_sticky_timeouts = {"dummy": 31337}
         self.timeout_man.config.sticky_connection_period = datetime.timedelta(seconds=1)
@@ -542,7 +544,7 @@ class TimeoutManagerTests(TestCase):
 
     def test_sticky_timeout_is_active(self):
         dev = DummyNMDevice()
-        dev.get_property = MagicMock(return_value="DEV1")
+        dev.get_property.return_value = "DEV1"
 
         self.timeout_man.keep_sticky_connections_until = {}
         self.assertFalse(self.timeout_man.sticky_timeout_is_active(dev))
@@ -1153,7 +1155,7 @@ class ConnectionManagerTests(TestCase):
     def test_apply_sim_slot_01_default_slot(self):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
-        dev.get_property = MagicMock(return_value="DUMMY_UDI")
+        dev.get_property.return_value = "DUMMY_UDI"
         self.con_man.modem_manager.get_primary_sim_slot = MagicMock(return_value=1)
         self.con_man.change_modem_sim_slot = MagicMock()
 
@@ -1168,7 +1170,7 @@ class ConnectionManagerTests(TestCase):
     def test_apply_sim_slot_02_current_slot(self):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
-        dev.get_property = MagicMock(return_value="DUMMY_UDI")
+        dev.get_property.return_value = "DUMMY_UDI"
         self.con_man.modem_manager.get_primary_sim_slot = MagicMock(return_value=1)
         self.con_man.change_modem_sim_slot = MagicMock()
 
@@ -1183,7 +1185,7 @@ class ConnectionManagerTests(TestCase):
     def test_apply_sim_slot_03_different_slot(self):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
-        dev.get_property = MagicMock(return_value="DUMMY_UDI")
+        dev.get_property.return_value = "DUMMY_UDI"
         self.con_man.modem_manager.get_primary_sim_slot = MagicMock(return_value=1)
         self.con_man.change_modem_sim_slot = MagicMock(return_value="CHANGE_RESULT")
 

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -189,6 +189,7 @@ class NetworkAwareConfigFile(ConfigFile):
         device = self.network_manager.find_device_for_connection(con)
         if not device:
             logging.warning("No device for connection %s found, will recheck later", cn_id)
+            return False
         managed = device.get_property("Managed")
         iface_name = device.get_property("Interface")
         if managed in (True, 1):

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -257,8 +257,12 @@ class TimeoutManager:  # pylint: disable=too-many-instance-attributes
         ):
             logging.debug("Sticky timeout is not active for device %s", device_name)
             return False
-        logging.debug("Sticky timeout is active for device %s", device_name)
-        return True
+        if dev.get_active_connection():
+            logging.debug("Sticky timeout is active for device %s", device_name)
+            return True
+        else:
+            logging.debug("Sticky timeout is active for device %s, but device is not active", device_name)
+            return False
 
 
 def read_config_json():

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -319,6 +319,8 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             self.set_current_connection(new_connection, new_tier)
             self.deactivate_lesser_gsm_connections(new_connection, new_tier)
             self.apply_metrics()
+        else:
+            self.deactivate_lesser_gsm_connections(new_connection, new_tier)
 
     def current_connection_has_connectivity(self):
         logging.debug("checking currently active connection %s", self.current_connection)

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -631,7 +631,9 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         logging.debug("Current connection is the same (%s), not changing", cn_id)
 
     def deactivate_lesser_gsm_connections(self, cn_id: str, tier: ConnectionTier) -> None:
+        logging.debug("Deactivating lesser GSM connections")
         connections = list(self.find_lesser_gsm_connections(cn_id, tier))
+        logging.debug("Found lesser GSM connections: %s", connections)
         for connection in connections:
             data = {"cn_id": connection.get_connection_id()}
             self.deactivate_connection(connection)

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -308,10 +308,7 @@ def check_connectivity(active_cn: NMActiveConnection, config: ConfigFile = None)
 
 
 def get_device_name(dev: NMDevice):
-    name = dev.get_property("IpInterface")
-    if not name:
-        logging.debug("Device %s has no IpInterface, using Interface", dev.get_path())
-        name = dev.get_property("Interface")
+    name = dev.get_property("Interface")
     logging.debug("Device %s name is %s", dev.get_path(), name)
     return name
 

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -188,8 +188,7 @@ class NetworkAwareConfigFile(ConfigFile):
         cn_id = con.get_connection_id()
         device = self.network_manager.find_device_for_connection(con)
         if not device:
-            logging.warning("No device for connection %s found, assuming unmnaged", cn_id)
-            return True
+            logging.warning("No device for connection %s found, will recheck later", cn_id)
         managed = device.get_property("Managed")
         iface_name = device.get_property("Interface")
         if managed in (True, 1):
@@ -380,6 +379,11 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                 "Sticky connections timeout active until %s, not touching sticky connections",
                 self.timeouts.keep_sticky_connections_until.isoformat(),
             )
+            return False
+        con = self.network_manager.find_connection(cn_id)
+        device = self.network_manager.find_device_for_connection(con)
+        if not device:
+            logging.warning("No device for connection %s found, will recheck later", cn_id)
             return False
         logging.debug("It is ok to activate connection %s", cn_id)
         return True

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -322,6 +322,14 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             self.config.sticky_connection_period.total_seconds(),
         )
 
+    def get_device_name(self, dev: NMDevice):
+        name = dev.get_property("IpInterface")
+        if not name:
+            logging.debug("LPNAME Device %s has no IpInterface, using Interface", dev.get_path())
+            name = dev.get_property("Interface")
+        logging.debug("Device %s name is %s", dev.get_path(), name)
+        return name
+
     def cycle_loop(self):
         new_tier, new_connection = self.check()
         if new_connection != self.current_connection or new_tier != self.current_tier:

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -307,7 +307,7 @@ def check_connectivity(active_cn: NMActiveConnection, config: ConfigFile = None)
 def get_device_name(dev: NMDevice):
     name = dev.get_property("IpInterface")
     if not name:
-        logging.debug("LPNAME Device %s has no IpInterface, using Interface", dev.get_path())
+        logging.debug("Device %s has no IpInterface, using Interface", dev.get_path())
         name = dev.get_property("Interface")
     logging.debug("Device %s name is %s", dev.get_path(), name)
     return name

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -260,9 +260,8 @@ class TimeoutManager:  # pylint: disable=too-many-instance-attributes
         if dev.get_active_connection():
             logging.debug("Sticky timeout is active for device %s", device_name)
             return True
-        else:
-            logging.debug("Sticky timeout is active for device %s, but device is not active", device_name)
-            return False
+        logging.debug("Sticky timeout is active for device %s, but device is not active", device_name)
+        return False
 
 
 def read_config_json():

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -633,7 +633,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
     def deactivate_lesser_gsm_connections(self, cn_id: str, tier: ConnectionTier) -> None:
         logging.debug("Deactivating lesser GSM connections")
         connections = list(self.find_lesser_gsm_connections(cn_id, tier))
-        logging.debug("Found lesser GSM connections: %s", connections)
+        logging.debug("Found %s lesser GSM connections", len(connections))
         for connection in connections:
             data = {"cn_id": connection.get_connection_id()}
             self.deactivate_connection(connection)


### PR DESCRIPTION
- соединения с ненайденными девайсами теперь не выбрасываются из конфигурации при старте wb-connection-manager (ранее при старте контроллера модем не находился и все модемные соединения считались перманентно unmanaged)
- отключение низкоприоритетных модемных соединений теперь осуществаляется не только при смене активного соединения, но и при каждом цикле проверок