### PR TITLE
Fix domain name resolving timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.7) stable; urgency=medium
+
+  * Fix domain name resolving timeout during connectivity checking
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 21 Jul 2023 15:31:28 +0500
+
 wb-nm-helper (1.27.6) stable; urgency=medium
 
   * Fix connectivity checking

--- a/wb/nm_helper/dns_resolver.py
+++ b/wb/nm_helper/dns_resolver.py
@@ -7,8 +7,10 @@ import pycares
 
 # Taken from https://github.com/saghul/pycares/blob/master/examples/cares-select.py
 def wait_pycares_channel(channel: pycares.Channel) -> None:
+    # Calc time enough to ask every server
+    timeout = channel.servers * 5000000000 + 1000000000
     start = time.monotonic_ns()
-    while time.monotonic_ns() - start < 5000000000:
+    while time.monotonic_ns() - start < timeout:
         read_fds, write_fds = channel.getsock()
         if not read_fds and not write_fds:
             break


### PR DESCRIPTION
5 секунд даётся на опрос одного сервера, если серверов несколько, и первые не отвечают, то мы можем вывалиться по общему таймауту, не дойдя до доступного сервера. Увеличим общий таймаут, чтобы успеть опросить все серверы.