### PR TITLE
Fix pkg-info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.27.9) stable; urgency=medium
+
+  * Fix PKG-INFO
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 24 Jul 2023 10:39:00 +0400
+
 wb-nm-helper (1.27.8) stable; urgency=medium
 
   * Fix domain name resolving timeout during connectivity checking

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,21 @@
 
 from setuptools import setup
 
+
+def get_version():
+    with open("debian/changelog", "r", encoding="utf-8") as f:
+        return f.readline().split()[1][1:-1]
+
+
 setup(
     name="wb-nm-helper",
-    version="1.0",
+    version=get_version(),
     description="wb-mqtt-confed backend for network configuration",
+    license="MIT",
     author="Petr Krasnoshchekov",
     author_email="petr.krasnoshchekov@wirenboard.ru",
+    maintainer="Wiren Board Team",
+    maintainer_email="info@wirenboard.com",
+    url="https://github.com/wirenboard/wb-nm-helper",
     packages=["wb.nm_helper"],
 )


### PR DESCRIPTION
Before:
```sh
$ cat /usr/lib/python3/dist-packages/wb_nm_helper-1.0.egg-info/PKG-INFO
Metadata-Version: 1.0
Name: wb-nm-helper
Version: 1.0
Summary: wb-mqtt-confed backend for network configuration
Home-page: UNKNOWN
Author: Petr Krasnoshchekov
Author-email: petr.krasnoshchekov@wirenboard.ru
License: UNKNOWN
Description: UNKNOWN
Platform: UNKNOWN
```
 After:
```sh
$ cat /usr/lib/python3/dist-packages/wb_nm_helper-1.27.9.egg-info/PKG-INFO
Metadata-Version: 1.2
Name: wb-nm-helper
Version: 1.27.9
Summary: wb-mqtt-confed backend for network configuration
Home-page: https://github.com/wirenboard/wb-nm-helper
Author: Petr Krasnoshchekov
Author-email: petr.krasnoshchekov@wirenboard.ru
Maintainer: Wiren Board Team
Maintainer-email: info@wirenboard.com
License: MIT
Description: UNKNOWN
Platform: UNKNOWN
```