### PR TITLE
Fix domain name resolving timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.28.1) stable; urgency=medium
+
+  * Fix domain name resolving timeout during connectivity checking
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 24 Jul 2023 20:39:35 +0500
+
 wb-nm-helper (1.28.0) stable; urgency=medium
 
   * Fix PKG-INFO

--- a/wb/nm_helper/dns_resolver.py
+++ b/wb/nm_helper/dns_resolver.py
@@ -37,6 +37,14 @@ class PycaresCallback:  # pylint: disable=R0903
 
 
 def resolve_domain_name(name: str, iface: str) -> str:
+    # From c-ares docs:
+    # timeout - the number of seconds each name server is given to respond to a query on the first try.
+    # tries - the number of tries the resolver will try contacting each name server before giving up.
+    # After the first try, the timeout algorithm becomes more complicated,
+    # but scales linearly with the value of timeout.
+    #
+    # Actually it multiplies timeout by 2 for every try.
+    # According to the settings it is 2, 4 and 8 seconds
     channel = pycares.Channel(tries=3, timeout=2)
     channel.set_local_dev(iface.encode())
     callback = PycaresCallback()

--- a/wb/nm_helper/dns_resolver.py
+++ b/wb/nm_helper/dns_resolver.py
@@ -46,6 +46,6 @@ def resolve_domain_name(name: str, iface: str) -> str:
         return callback.result.addresses[0]
     raise DomainNameResolveException(
         "Error during {} resolving: {}".format(
-            name, "timeout" if callback.error is None else pycares.errno.strerror(callback.error)
+            name, "can't get address" if callback.error is None else pycares.errno.strerror(callback.error)
         )
     )


### PR DESCRIPTION
pycares has internal timeout logic, use it instead of badly calculated timeout

Я неверно интерпретировал документацию на pycares. У него есть внутренний таймаут на все запросы. Если он истекает, возвращается ошибка. Таймаут контролируется 2-я параметрами `timeout` и `tries`. Первый - начальный таймаут на запрос к серверу, второй - число попыток запросить. При каждой новой попытке таймаут увеличивается вдвое.