### PR TITLE
Feature/65308 change cn errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-nm-helper (1.29.3) stable; urgency=medium
 
-  * Fix build, no functional changes
+  * Bugfix for issue with no working connections
 
  -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 13 Sep 2023 13:47:00 +0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-nm-helper (1.29.3) stable; urgency=medium
 
-  * Bugfix for issue with no working connections
+  * Fix crash when no working connection was found
 
  -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 13 Sep 2023 13:47:00 +0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.29.3) stable; urgency=medium
+
+  * Fix build, no functional changes
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 13 Sep 2023 13:47:00 +0600
+
 wb-nm-helper (1.29.2) stable; urgency=medium
 
   * Fix build, no functional changes

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1991,11 +1991,8 @@ class ConnectionManagerTests(TestCase):
 
         result = list(self.con_man.find_lesser_gsm_connections("wb-gsm1", None))
 
-        self.assertEqual(
-            [], self.con_man.connection_is_gsm.mock_calls
-        )
+        self.assertEqual([], self.con_man.connection_is_gsm.mock_calls)
         self.assertEqual([], result)
-
 
     def test_find_lesser_gsm_connections_01_current_is_gsm(self):
         self.con_man.config.tiers = [

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1980,6 +1980,23 @@ class ConnectionManagerTests(TestCase):
         self.assertEqual([call("wb-eth1", "dummy_tier")], self.con_man.find_lesser_gsm_connections.mock_calls)
         self.assertEqual([call(con), call(con2)], self.con_man.deactivate_connection.mock_calls)
 
+    def test_find_lesser_gsm_connections_00_no_current_tier(self):
+        self.con_man.config.tiers = [
+            connection_manager.ConnectionTier("first_tier", 3, ["wb-eth0", "wb-gsm0"]),
+            connection_manager.ConnectionTier("second_tier", 2, ["wb-eth1", "wb-gsm1"]),
+            connection_manager.ConnectionTier("third_tier", 1, ["wb-eth2", "wb-gsm2"]),
+        ]
+        self.con_man.connection_is_gsm = MagicMock(side_effect=[False, False, True])
+        self.con_man.find_active_connection = MagicMock(return_value="dummy_con")
+
+        result = list(self.con_man.find_lesser_gsm_connections("wb-gsm1", None))
+
+        self.assertEqual(
+            [], self.con_man.connection_is_gsm.mock_calls
+        )
+        self.assertEqual([], result)
+
+
     def test_find_lesser_gsm_connections_01_current_is_gsm(self):
         self.con_man.config.tiers = [
             connection_manager.ConnectionTier("first_tier", 3, ["wb-eth0", "wb-gsm0"]),

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -645,9 +645,6 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         if not current_tier:
             logging.debug("Current tier is not set, no lesser connections")
             return
-        logging.debug('Current tier is "%s"', current_tier)
-        for tier in self.config.tiers:
-            logging.debug('Checking tier "%s"', tier)
         for tier in [item for item in self.config.tiers if item.priority <= current_tier.priority]:
             for cn_id in [
                 item for item in tier.connections if item != current_con_id and self.connection_is_gsm(item)

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -642,7 +642,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
     def find_lesser_gsm_connections(
         self, current_con_id: str, current_tier: ConnectionTier
     ) -> Iterator[NMActiveConnection]:
-        if not self.current_tier:
+        if not current_tier:
             logging.debug("Current tier is not set, no lesser connections")
             return
         logging.debug('Current tier is "%s"', current_tier)

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -642,9 +642,12 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
     def find_lesser_gsm_connections(
         self, current_con_id: str, current_tier: ConnectionTier
     ) -> Iterator[NMActiveConnection]:
-        logging.debug('current tier is "%s"', current_tier)
+        if not self.current_tier:
+            logging.debug("Current tier is not set, no lesser connections")
+            return
+        logging.debug('Current tier is "%s"', current_tier)
         for tier in self.config.tiers:
-            logging.debug('checking tier "%s"', tier)
+            logging.debug('Checking tier "%s"', tier)
         for tier in [item for item in self.config.tiers if item.priority <= current_tier.priority]:
             for cn_id in [
                 item for item in tier.connections if item != current_con_id and self.connection_is_gsm(item)

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -642,6 +642,9 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
     def find_lesser_gsm_connections(
         self, current_con_id: str, current_tier: ConnectionTier
     ) -> Iterator[NMActiveConnection]:
+        logging.debug('current tier is "%s"', current_tier)
+        for tier in self.config.tiers:
+            logging.debug('checking tier "%s"', tier)
         for tier in [item for item in self.config.tiers if item.priority <= current_tier.priority]:
             for cn_id in [
                 item for item in tier.connections if item != current_con_id and self.connection_is_gsm(item)


### PR DESCRIPTION
В ситуации, когда нет current tier (например, не получилось обнаружить работающее соединение), попытка вычислить lesser gsm connections падала с ошибкой из-за попытки обращения к current_tier.priority.