### PR TITLE
Add option to configure gsm connection deactivation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.31.0) stable; urgency=medium
+
+  * Add option to configure gsm connection deactivation by priority
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 10 Nov 2023 14:21:19 +0500
+
 wb-nm-helper (1.30.0) stable; urgency=medium
 
   * Source code refactoring. No functional changes

--- a/debian/wb-nm-helper.install
+++ b/debian/wb-nm-helper.install
@@ -8,3 +8,4 @@ share/99-disable-if-not-configured.conf /usr/lib/systemd/system/hostapd.service.
 share/99-disable-if-not-configured.conf /usr/lib/systemd/system/dnsmasq.service.d
 bin/wb-disable-nat /usr/lib/NetworkManager/dispatcher.d
 bin/wb-mqtt-nm-helper /usr/bin
+share/wb-connection-manager.conf /usr/share/dbus-1/system.d

--- a/share/wb-connection-manager.conf
+++ b/share/wb-connection-manager.conf
@@ -1,0 +1,12 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="com.wirenboard.wb-connection-manager"/>
+    <allow send_destination="com.wirenboard.wb-connection-manager"/>
+  </policy>
+  <policy context="default">
+    <allow own="com.wirenboard.wb-connection-manager"/>
+    <allow send_destination="com.wirenboard.wb-connection-manager"/>
+  </policy>
+</busconfig>

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1968,9 +1968,9 @@ class ConnectionManagerTests(TestCase):
         self.assertEqual([call("wb-eth1")], self.con_man.network_manager.find_connection.mock_calls)
 
     def test_deactivate_lesser_gsm_connections(self):
-        settings_close = {"user": {"data": {"wb.close-by-priority": True}}}
+        settings_close = {"user": {"data": {"wb.close-by-priority": "true"}}}
         settings_do_not_close = {}
-        settings_do_not_close2 = {"user": {"data": {"wb.close-by-priority": False}}}
+        settings_do_not_close2 = {"user": {"data": {"wb.close-by-priority": "false"}}}
 
         con = DummyNMActiveConnection()
         con.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm0", settings_close))

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1968,11 +1968,24 @@ class ConnectionManagerTests(TestCase):
         self.assertEqual([call("wb-eth1")], self.con_man.network_manager.find_connection.mock_calls)
 
     def test_deactivate_lesser_gsm_connections(self):
-        con = DummyNMConnection("wb-gsm0", {})
+        settings_close = {"user": {"data": {"wb.close-by-priority": True}}}
+        settings_do_not_close = {}
+        settings_do_not_close2 = {"user": {"data": {"wb.close-by-priority": False}}}
+
+        con = DummyNMActiveConnection()
+        con.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm0", settings_close))
         con.get_connection_id = MagicMock(return_value="wb-gsm0")
-        con2 = DummyNMConnection("wb-gsm1", {})
+        con2 = DummyNMActiveConnection()
         con2.get_connection_id = MagicMock(return_value="wb-gsm1")
-        self.con_man.find_lesser_gsm_connections = MagicMock(return_value=[con, con2])
+        con2.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm1", settings_close))
+        con3 = DummyNMActiveConnection()
+        con3.get_connection_id = MagicMock(return_value="wb-gsm2")
+        con3.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm2", settings_do_not_close))
+        con4 = DummyNMActiveConnection()
+        con4.get_connection_id = MagicMock(return_value="wb-gsm3")
+        con4.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm3", settings_do_not_close2))
+
+        self.con_man.find_lesser_gsm_connections = MagicMock(return_value=[con, con2, con3, con4])
         self.con_man.deactivate_connection = MagicMock()
 
         self.con_man.deactivate_lesser_gsm_connections("wb-eth1", "dummy_tier")
@@ -2055,11 +2068,15 @@ class MainTests(TestCase):
         connection_manager.NetworkManager = DummyNetworkManager
         connection_manager.NetworkAwareConfigFile = DummyConfigFile
         connection_manager.ModemManager = DummyModemManager
+        connection_manager.dbus.SystemBus = MagicMock()
+        connection_manager.dbus.SystemBus.add_message_filter = MagicMock()
+        connection_manager.request_dbus_name = MagicMock()
 
         self.dummy_json = DummyBytesIO()
 
     def tearDown(self) -> None:
         importlib.reload(connection_manager)
+        importlib.reload(dbus)
 
     def test_json_loading_errors_01_file_not_found(self):
         connection_manager.read_config_json = MagicMock(side_effect=FileNotFoundError())

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1983,7 +1983,9 @@ class ConnectionManagerTests(TestCase):
         con3.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm2", settings_do_not_deactivate))
         con4 = DummyNMActiveConnection()
         con4.get_connection_id = MagicMock(return_value="wb-gsm3")
-        con4.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm3", settings_do_not_deactivate2))
+        con4.get_connection = MagicMock(
+            return_value=DummyNMConnection("wb-gsm3", settings_do_not_deactivate2)
+        )
 
         self.con_man.find_lesser_gsm_connections = MagicMock(return_value=[con, con2, con3, con4])
         self.con_man.deactivate_connection = MagicMock()

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1968,22 +1968,22 @@ class ConnectionManagerTests(TestCase):
         self.assertEqual([call("wb-eth1")], self.con_man.network_manager.find_connection.mock_calls)
 
     def test_deactivate_lesser_gsm_connections(self):
-        settings_close = {"user": {"data": {"wb.close-by-priority": "true"}}}
-        settings_do_not_close = {}
-        settings_do_not_close2 = {"user": {"data": {"wb.close-by-priority": "false"}}}
+        settings_deactivate = {"user": {"data": {"wb.deactivate-by-priority": "true"}}}
+        settings_do_not_deactivate = {}
+        settings_do_not_deactivate2 = {"user": {"data": {"wb.deactivate-by-priority": "false"}}}
 
         con = DummyNMActiveConnection()
-        con.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm0", settings_close))
+        con.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm0", settings_deactivate))
         con.get_connection_id = MagicMock(return_value="wb-gsm0")
         con2 = DummyNMActiveConnection()
         con2.get_connection_id = MagicMock(return_value="wb-gsm1")
-        con2.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm1", settings_close))
+        con2.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm1", settings_deactivate))
         con3 = DummyNMActiveConnection()
         con3.get_connection_id = MagicMock(return_value="wb-gsm2")
-        con3.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm2", settings_do_not_close))
+        con3.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm2", settings_do_not_deactivate))
         con4 = DummyNMActiveConnection()
         con4.get_connection_id = MagicMock(return_value="wb-gsm3")
-        con4.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm3", settings_do_not_close2))
+        con4.get_connection = MagicMock(return_value=DummyNMConnection("wb-gsm3", settings_do_not_deactivate2))
 
         self.con_man.find_lesser_gsm_connections = MagicMock(return_value=[con, con2, con3, con4])
         self.con_man.deactivate_connection = MagicMock()

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -951,10 +951,18 @@
                             },
                             "enum": ["02_nm_modem"]
                         },
+                        "close-by-priority": {
+                            "title": "Close if higher priority connection is active",
+                            "description": "Helps to avoid service traffic when metered connection is active",
+                            "type": "boolean",
+                            "default": false,
+                            "_format": "checkbox",
+                            "propertyOrder": 4
+                        },
                         "gsm_apn": {
                             "type": "string",
                             "title": "APN",
-                            "propertyOrder": 4,
+                            "propertyOrder": 5,
                             "options": {
                                 "inputAttributes": {
                                     "placeholder":  "gsm_auto-config_title"
@@ -967,7 +975,7 @@
                                 {"$ref": "#/definitions/nm_ipv4_auto"},
                                 {"$ref": "#/definitions/nm_ipv4_manual"}
                             ],
-                            "propertyOrder": 5,
+                            "propertyOrder": 6,
                             "options": {
                                 "keep_oneof_values": false
                             }
@@ -977,7 +985,7 @@
                             "title": "Only for SIM slot",
                             "enum": [1, 2],
                             "default": 1,
-                            "propertyOrder": 6,
+                            "propertyOrder": 7,
                             "options": {
                                 "inputAttributes": {
                                     "placeholder":  "any SIM-slot"
@@ -988,7 +996,7 @@
                         "connection_interface-name": {
                             "type": "string",
                             "title": "Only for device",
-                            "propertyOrder": 7,
+                            "propertyOrder": 8,
                             "options": {
                                 "inputAttributes": {
                                     "placeholder":  "use with any suitable device"
@@ -1546,7 +1554,9 @@
             "Medium-priority connections": "Соединения со средним приоритетом",
             "Low-priority connections": "Соединения с низким приоритетом",
             "Encryption": "Шифрование",
-            "For maximum compatibility set to Auto": "Для максимальной совместимости оставьте Auto"
+            "For maximum compatibility set to Auto": "Для максимальной совместимости оставьте Auto",
+            "Close if higher priority connection is active": "Отключать, если активно другое соединение с более высоким приоритетом",
+            "Helps to avoid service traffic when metered connection is active": "Позволяет избежать расходов на служебный трафик, если соединение не используется"
         }
     }
 }

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -951,8 +951,8 @@
                             },
                             "enum": ["02_nm_modem"]
                         },
-                        "close-by-priority": {
-                            "title": "Close if higher priority connection is active",
+                        "deactivate-by-priority": {
+                            "title": "Deactivate, if higher priority connection is active",
                             "description": "Helps to avoid service traffic when metered connection is active",
                             "type": "boolean",
                             "default": false,
@@ -1555,7 +1555,7 @@
             "Low-priority connections": "Соединения с низким приоритетом",
             "Encryption": "Шифрование",
             "For maximum compatibility set to Auto": "Для максимальной совместимости оставьте Auto",
-            "Close if higher priority connection is active": "Отключать, если активно другое соединение с более высоким приоритетом",
+            "Deactivate, if higher priority connection is active": "Отключать, если активно другое соединение с более высоким приоритетом",
             "Helps to avoid service traffic when metered connection is active": "Позволяет избежать расходов на служебный трафик, если соединение не используется"
         }
     }

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -640,7 +640,8 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                 .get_settings()
                 .get("user", {})
                 .get("data", {})
-                .get("wb.close-by-priority", False)
+                .get("wb.close-by-priority", "false")
+                == "true"
             ):
                 self.deactivate_connection(connection)
                 logging.info(

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -45,6 +45,10 @@ DEFAULT_CONNECTIVITY_CHECK_URL = "http://network-test.debian.org/nm"
 DEFAULT_CONNECTIVITY_CHECK_PAYLOAD = "NetworkManager is online"
 DBUS_SERVICE_NAME = "com.wirenboard.wb-connection-manager"
 
+DBUS_NAME_FLAG_ALLOW_REPLACEMENT = 1
+DBUS_NAME_FLAG_REPLACE_EXISTING = 2
+DBUS_NAME_FLAG_DO_NOT_QUEUE = 4
+
 
 class ImproperlyConfigured(ValueError):
     pass
@@ -728,7 +732,12 @@ def init_logging(debug: bool):
 def request_dbus_name(bus, name: str) -> None:
     obj_dbus = bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
     iface = dbus.Interface(obj_dbus, "org.freedesktop.DBus")
-    iface.RequestName(name, dbus.UInt32(0))
+    iface.RequestName(
+        name,
+        dbus.UInt32(
+            DBUS_NAME_FLAG_ALLOW_REPLACEMENT | DBUS_NAME_FLAG_REPLACE_EXISTING | DBUS_NAME_FLAG_DO_NOT_QUEUE
+        ),
+    )
 
 
 def main():

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -644,7 +644,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                 .get_settings()
                 .get("user", {})
                 .get("data", {})
-                .get("wb.close-by-priority", "false")
+                .get("wb.deactivate-by-priority", "false")
                 == "true"
             ):
                 self.deactivate_connection(connection)
@@ -652,7 +652,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                     'Deactivated unneeded GSM connection "%s" to save GSM traffic', data["cn_id"], extra=data
                 )
             else:
-                logging.debug('It is forbidden to close GSM connection "%s"', data["cn_id"], extra=data)
+                logging.debug('It is forbidden to deactivate GSM connection "%s"', data["cn_id"], extra=data)
 
     def find_lesser_gsm_connections(
         self, current_con_id: str, current_tier: ConnectionTier

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -444,14 +444,14 @@ class ModemConnection(Connection):
             con.set_value("gsm.auto-config", False)
         else:
             con.set_value("gsm.auto-config", True)
-        if iface.get_opt("close-by-priority", False):
+        if iface.get_opt("deactivate-by-priority", False):
             user_data = con.get_opt("user.data", dbus.Dictionary(signature="ss"))
-            user_data["wb.close-by-priority"] = "true"
+            user_data["wb.deactivate-by-priority"] = "true"
             con.set_value("user.data", user_data)
         else:
             user_data = con.get_opt("user.data")
-            if user_data is not None and user_data.get("wb.close-by-priority") is not None:
-                user_data["wb.close-by-priority"] = "false"
+            if user_data is not None and user_data.get("wb.deactivate-by-priority") is not None:
+                user_data["wb.deactivate-by-priority"] = "false"
                 con.set_value("user.data", user_data)
 
     def get_connection(self, con: NMConnection):
@@ -459,9 +459,9 @@ class ModemConnection(Connection):
         if res is not None:
             user_data = self.get_dbus_settings(con).get_opt("user.data")
             if user_data is None or not res["connection_autoconnect"]:
-                res["close-by-priority"] = False
+                res["deactivate-by-priority"] = False
             else:
-                res["close-by-priority"] = user_data.get("wb.close-by-priority", "false") == "true"
+                res["deactivate-by-priority"] = user_data.get("wb.deactivate-by-priority", "false") == "true"
         return res
 
 

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -446,12 +446,12 @@ class ModemConnection(Connection):
             con.set_value("gsm.auto-config", True)
         if iface.get_opt("close-by-priority", False):
             user_data = con.get_opt("user.data", dbus.Dictionary(signature="ss"))
-            user_data["wb.close-by-priority"] = True
+            user_data["wb.close-by-priority"] = "true"
             con.set_value("user.data", user_data)
         else:
             user_data = con.get_opt("user.data")
             if user_data is not None and user_data.get("wb.close-by-priority") is not None:
-                user_data["wb.close-by-priority"] = False
+                user_data["wb.close-by-priority"] = "false"
                 con.set_value("user.data", user_data)
 
     def get_connection(self, con: NMConnection):
@@ -461,7 +461,7 @@ class ModemConnection(Connection):
             if user_data is None or not res["connection_autoconnect"]:
                 res["close-by-priority"] = False
             else:
-                res["close-by-priority"] = user_data.get("wb.close-by-priority", False)
+                res["close-by-priority"] = user_data.get("wb.close-by-priority", "false") == "true"
         return res
 
 

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import dbus
+import dbus.lowlevel
 import dbus.mainloop.glib
 import dbus.types
 from gi.repository import GLib
@@ -20,7 +21,7 @@ from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 from wb.nm_helper import wbmqtt
 from wb.nm_helper.connection_checker import ConnectionChecker
-from wb.nm_helper.connection_manager import check_connectivity
+from wb.nm_helper.connection_manager import DBUS_SERVICE_NAME, check_connectivity
 from wb.nm_helper.network_manager import NMActiveConnection
 
 CONNECTIVITY_CHECK_PERIOD = 20
@@ -70,18 +71,19 @@ class EventLoop:
 
 
 class EventType(enum.Enum):
-    COMMON_CREATE = 1
-    COMMON_SWITCH = 2
-    COMMON_REMOVE = 3
+    COMMON_CREATE = enum.auto()
+    COMMON_SWITCH = enum.auto()
+    COMMON_REMOVE = enum.auto()
 
-    ACTIVE_PROPERTIES_UPDATED = 4
-    ACTIVE_CONNECTIVITY_UPDATED = 5
-    ACTIVE_MODEM_STATE_UPDATED = 6
+    ACTIVE_PROPERTIES_UPDATED = enum.auto()
+    ACTIVE_CONNECTIVITY_UPDATED = enum.auto()
+    ACTIVE_MODEM_STATE_UPDATED = enum.auto()
+    ACTIVE_DEACTIVATED_BY_WB_CM = enum.auto()
 
-    ACTIVE_LIST_UPDATE = 7
-    CONNECTIVITY_REQUEST = 9
+    ACTIVE_LIST_UPDATE = enum.auto()
+    CONNECTIVITY_REQUEST = enum.auto()
 
-    RELOAD = 10
+    RELOAD = enum.auto()
 
 
 class Event:
@@ -183,7 +185,7 @@ class MqttConnectionState:  # pylint: disable=R0902
     access_tech: str = None
 
 
-class ConnectionsMediator(Mediator):
+class ConnectionsMediator(Mediator):  # pylint: disable=R0902
     def __init__(self, mqtt_client) -> None:
         super().__init__()
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
@@ -198,6 +200,7 @@ class ConnectionsMediator(Mediator):
         self._connectivity_updater = ConnectivityUpdater(self, self._bus)
 
         self._set_connections_event_handlers()
+        self._deactivation_monitor = DeactivationMonitor(self)
 
     def run(self):
         self._event_loop.run()
@@ -391,6 +394,13 @@ class ConnectionsMediator(Mediator):
         if connection is not None:
             connection.update(state)
 
+    def _active_connection_deactivated_by_cm(self, active_connection_path: str) -> None:
+        active_connection = self._active_connections.get(active_connection_path)
+        if active_connection is not None:
+            connection = self._common_connections.get(active_connection.connection_path)
+            if connection is not None:
+                connection.set_deactivated_by_wb_cm()
+
     async def _run_async_event(self, event: Event):
         logging.debug("Execute event %s %s %s", event.number, event.type.name, event.kwargs)
         try:
@@ -421,6 +431,10 @@ class ConnectionsMediator(Mediator):
 
             elif event.type == EventType.RELOAD:
                 self._reload_connectivity()
+
+            elif event.type == EventType.ACTIVE_DEACTIVATED_BY_WB_CM:
+                self._active_connection_deactivated_by_cm(event.kwargs.get("active_connection_path"))
+
         except BaseException as ex:
             logging.error(
                 "Error during event execution %s",
@@ -571,6 +585,7 @@ class CommonConnection:  # pylint: disable=R0902
         self._name = None
         self._uuid = None
         self._mqtt_device = None
+        self._deactivated_by_wb_cm = False
 
         logging.info("New connection %s", self.dbus_path)
 
@@ -585,7 +600,17 @@ class CommonConnection:  # pylint: disable=R0902
         self._mqtt_device.set_control_value("Active", "1" if state.active else "0")
         self._mqtt_device.set_control_title("UpDown", "Down" if state.active else "Up")
         self._mqtt_device.set_control_value("Device", state.device)
-        self._mqtt_device.set_control_value("State", state.state.name.lower())
+
+        if state.state in (ConnectionState.ACTIVATED, ConnectionState.ACTIVATING):
+            self._deactivated_by_wb_cm = False
+        state_name = state.state.name.lower()
+        if self._deactivated_by_wb_cm and state.state in (
+            ConnectionState.DEACTIVATED,
+            ConnectionState.DEACTIVATING,
+        ):
+            state_name = state_name + " by wb-connection-manager"
+        self._mqtt_device.set_control_value("State", state_name)
+
         self._mqtt_device.set_control_value("Address", state.address)
         self._mqtt_device.set_control_value("Connectivity", "1" if state.connectivity else "0")
         if self._type == "gsm":
@@ -600,6 +625,10 @@ class CommonConnection:  # pylint: disable=R0902
         deactivated_state = MqttConnectionState()
         deactivated_state.state = ConnectionState.DEACTIVATED
         self.update(deactivated_state)
+
+    def set_deactivated_by_wb_cm(self) -> None:
+        if self._type == "gsm":
+            self._deactivated_by_wb_cm = True
 
     def stop(self):
         self._remove_virtual_device()
@@ -660,6 +689,34 @@ class CommonConnection:  # pylint: disable=R0902
         if self._mqtt_device is not None:
             self._mqtt_device.remove_device()
         logging.info("Remove virtual device %s %s %s", self._name, self._uuid, self.dbus_path)
+
+
+class DeactivationMonitor:
+    def __init__(self, mediator: Mediator) -> None:
+        self._mediator = mediator
+        self._private_bus = dbus.SystemBus(private=True)
+
+        obj_dbus = self._private_bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        iface = dbus.Interface(obj_dbus, "org.freedesktop.DBus.Monitoring")
+        iface.BecomeMonitor(
+            [
+                "member=DeactivateConnection,sender=" + DBUS_SERVICE_NAME,
+            ],
+            dbus.UInt32(0),
+        )
+
+        self._private_bus.add_message_filter(self)
+
+    def __call__(self, _bus, msg: dbus.lowlevel.Message) -> None:
+        args = msg.get_args_list()
+        if args[0].startswith("/org/freedesktop/NetworkManager/ActiveConnection"):
+            logging.debug("Connection deactivation from %s\n%s", msg.get_sender(), args)
+            self._mediator.new_event(
+                Event(EventType.ACTIVE_DEACTIVATED_BY_WB_CM, active_connection_path=args[0])
+            )
+
+    def stop(self) -> None:
+        self._private_bus.close()
 
 
 class ModemAccessTechnology(enum.Enum):

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -36,7 +36,7 @@ def has_permanent_connectivity(active_connection: NMActiveConnection) -> bool:
             return True
         if settings.get("802-11-wireless", {}).get("mode") == "ap":
             return True
-        return settings.get("user", {}).get("data", {}).get("wb.read-only", False)
+        return settings.get("user", {}).get("data", {}).get("wb.read-only", "false") == "true"
     except dbus.exceptions.DBusException as ex:
         logging.debug("Can't define if connection has permanent connectivity: %s", ex)
         return False


### PR DESCRIPTION
Сделано на основании https://github.com/wirenboard/wb-nm-helper/pull/88. Здесь только функциональные изменения согласно поставленной задаче. Рефакторинг заехал отдельным PR.

Добавил параметр в настройки соединения, который говорит, что переключалка может отключать его, если активно более приоритетное.
Добавил в публикатор вывод статуса, что соединение закрыто переключалкой.

Для полной картины надо ещё вот это поставить https://github.com/wirenboard/homeui/pull/482