### PR TITLE
Fix /etc/network/interfaces parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-nm-helper (1.31.1) stable; urgency=medium
+
+  * Fix parsing of hwaddress in /etc/network/interfaces
+  * Fix filtering interfaces without type in /etc/network/interfaces
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 22 Nov 2023 12:17:31 +0500
+
 wb-nm-helper (1.31.0) stable; urgency=medium
 
   * Add option to configure gsm connection deactivation by priority

--- a/tests/data/interfaces
+++ b/tests/data/interfaces
@@ -29,6 +29,10 @@ iface eth1 inet dhcp
    pre-up #test
    hostname WirenBoard
 
+allow-hotplug eth2
+iface eth2 inet dhcp
+  hwaddress ether 94:C6:91:91:4D:5A
+
 allow-hotplug can0
 iface can0 can static
    bitrate 125000
@@ -40,3 +44,6 @@ iface can0 can static
 #iface ppp0 inet ppp
 ## select provider: megafon, mts or beeline below
 #  provider megafon
+
+# filter interfaces without type
+auto eth3

--- a/tests/data/interfaces_generated
+++ b/tests/data/interfaces_generated
@@ -19,7 +19,7 @@ iface eth1 inet dhcp
 
 allow-hotplug eth2
 iface eth2 inet dhcp
-  hwaddress ether 94:C6:91:91:4D:5A
+  hwaddress 94:C6:91:91:4D:5A
 
 auto wlan0
 allow-hotplug wlan0

--- a/tests/data/interfaces_generated
+++ b/tests/data/interfaces_generated
@@ -17,6 +17,10 @@ iface eth1 inet dhcp
   pre-up sleep 10   # comment2
   pre-up #test
 
+allow-hotplug eth2
+iface eth2 inet dhcp
+  hwaddress ether 94:C6:91:91:4D:5A
+
 auto wlan0
 allow-hotplug wlan0
 iface wlan0 inet static

--- a/tests/data/interfaces_hwaddress
+++ b/tests/data/interfaces_hwaddress
@@ -1,0 +1,7 @@
+allow-hotplug eth0
+iface eth0 inet dhcp
+  hwaddress 94:C6:91:91:4D:5A
+
+allow-hotplug eth1
+iface eth1 inet dhcp
+  hwaddress ether  94:C6:91:91:4D:6A

--- a/tests/data/ui.json
+++ b/tests/data/ui.json
@@ -131,6 +131,17 @@
         "type": "dhcp"
       },
       {
+        "name": "eth2",
+        "auto": false,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hwaddress": "94:C6:91:91:4D:5A"
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
         "name": "wlan0",
         "auto": false,
         "mode": "inet",

--- a/tests/test_network_interfaces_adapter.py
+++ b/tests/test_network_interfaces_adapter.py
@@ -23,7 +23,31 @@ from wb.nm_helper.network_interfaces_adapter import NetworkInterfacesAdapter
                     "type": "can",
                 }
             ],
-        )
+        ),
+        (
+            # hwaddress
+            "tests/data/interfaces_hwaddress",
+            [
+                {
+                    "allow-hotplug": True,
+                    "auto": False,
+                    "method": "dhcp",
+                    "mode": "inet",
+                    "name": "eth0",
+                    "options": {"hwaddress": "94:C6:91:91:4D:5A"},
+                    "type": "dhcp",
+                },
+                {
+                    "allow-hotplug": True,
+                    "auto": False,
+                    "method": "dhcp",
+                    "mode": "inet",
+                    "name": "eth1",
+                    "options": {"hwaddress": "94:C6:91:91:4D:6A"},
+                    "type": "dhcp",
+                },
+            ],
+        ),
     ],
 )
 def test_parsing(file_name, connections):
@@ -39,7 +63,7 @@ def test_apply_no_changes():
 
     res = adapter.apply(cfg["ui"]["connections"], True)
     assert len(res.unmanaged_connections) == 5
-    assert res.managed_interfaces == ["can0", "eth0", "eth1", "wlan0"]
+    assert res.managed_interfaces == ["can0", "eth0", "eth1", "eth2", "wlan0"]
     assert not res.released_interfaces
     assert res.is_changed is False
 
@@ -52,10 +76,10 @@ def test_apply_changes():
 
     adapter = NetworkInterfacesAdapter("tests/data/interfaces")
 
-    cfg["ui"]["connections"][8]["auto"] = True
+    cfg["ui"]["connections"][9]["auto"] = True
     res = adapter.apply(cfg["ui"]["connections"], True)
     assert len(res.unmanaged_connections) == 5
-    assert res.managed_interfaces == ["can0", "eth0", "eth1", "wlan0"]
+    assert res.managed_interfaces == ["can0", "eth0", "eth1", "eth2", "wlan0"]
     assert not res.released_interfaces
     assert res.is_changed is True
     assert adapter.format() == generated
@@ -67,9 +91,9 @@ def test_apply_remove_iface():
 
     adapter = NetworkInterfacesAdapter("tests/data/interfaces")
 
-    del cfg["ui"]["connections"][8]
+    del cfg["ui"]["connections"][9]
     res = adapter.apply(cfg["ui"]["connections"], True)
     assert len(res.unmanaged_connections) == 5
-    assert res.managed_interfaces == ["can0", "eth0", "eth1"]
+    assert res.managed_interfaces == ["can0", "eth0", "eth1", "eth2"]
     assert res.released_interfaces == ["wlan0"]
     assert res.is_changed is False

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -219,7 +219,7 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         assert res["data"]["devices"][3]["iface"] == "wlan1"
         assert res["data"]["devices"][3]["type"] == "wifi"
         assert res["ui"]["con_switch"]["debug"] is False
-        assert len(res["ui"]["connections"]) == 9
+        assert len(res["ui"]["connections"]) == 10
         assert res["ui"]["connections"][0]["802-11-wireless-security"]["security"] == "none"
         assert res["ui"]["connections"][0]["802-11-wireless_mode"] == "ap"
         assert res["ui"]["connections"][0]["802-11-wireless_ssid"] == "WirenBoard-Тест"
@@ -287,11 +287,18 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         assert res["ui"]["connections"][7]["type"] == "dhcp"
         assert res["ui"]["connections"][8]["allow-hotplug"] is True
         assert res["ui"]["connections"][8]["auto"] is False
-        assert res["ui"]["connections"][8]["method"] == "static"
-        assert res["ui"]["connections"][8]["mode"] == "can"
-        assert res["ui"]["connections"][8]["name"] == "can0"
-        assert res["ui"]["connections"][8]["options"]["bitrate"] == 125000
-        assert res["ui"]["connections"][8]["type"] == "can"
+        assert res["ui"]["connections"][8]["method"] == "dhcp"
+        assert res["ui"]["connections"][8]["mode"] == "inet"
+        assert res["ui"]["connections"][8]["name"] == "eth2"
+        assert res["ui"]["connections"][8]["options"]["hwaddress"] == "94:C6:91:91:4D:5A"
+        assert res["ui"]["connections"][8]["type"] == "dhcp"
+        assert res["ui"]["connections"][9]["allow-hotplug"] is True
+        assert res["ui"]["connections"][9]["auto"] is False
+        assert res["ui"]["connections"][9]["method"] == "static"
+        assert res["ui"]["connections"][9]["mode"] == "can"
+        assert res["ui"]["connections"][9]["name"] == "can0"
+        assert res["ui"]["connections"][9]["options"]["bitrate"] == 125000
+        assert res["ui"]["connections"][9]["type"] == "can"
 
 
 class FakeNMAdapter(NetworkManagerAdapter):

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -178,7 +178,10 @@ class NetworkInterfacesAdapter:
             options = iface.get("options", {})
             for opt_key, opt_val in options_generator(options):
                 if opt_val not in ("", None):
-                    output += f"  {opt_key} {opt_val}\n"
+                    if opt_key == "hwaddress":
+                        output += f"  hwaddress ether {opt_val}\n"
+                    else:
+                        output += f"  {opt_key} {opt_val}\n"
             output += "\n"
         return output
 
@@ -186,6 +189,9 @@ class NetworkInterfacesAdapter:
         """
         Convert iface options according to schema
         """
+        if "options" not in iface:
+            return
+
         for key, value in iface["options"].items():
             if key not in ("pre-up", "up", "post-up", "pre-down", "down", "post-down"):
                 iface["options"][key] = value[0] if len(value) == 1 else value
@@ -195,6 +201,11 @@ class NetworkInterfacesAdapter:
             iface["type"] = "can"
             if "options" in iface and "bitrate" in iface["options"]:
                 iface["options"]["bitrate"] = int(iface["options"]["bitrate"])
+
+        if "hwaddress" in iface["options"]:
+            hwaddress_value = iface["options"]["hwaddress"]
+            if hwaddress_value.startswith("ether"):
+                iface["options"]["hwaddress"] = hwaddress_value[5:].strip()
 
     def get_interfaces(self):
         """

--- a/wb/nm_helper/network_interfaces_adapter.py
+++ b/wb/nm_helper/network_interfaces_adapter.py
@@ -178,10 +178,7 @@ class NetworkInterfacesAdapter:
             options = iface.get("options", {})
             for opt_key, opt_val in options_generator(options):
                 if opt_val not in ("", None):
-                    if opt_key == "hwaddress":
-                        output += f"  hwaddress ether {opt_val}\n"
-                    else:
-                        output += f"  {opt_key} {opt_val}\n"
+                    output += f"  {opt_key} {opt_val}\n"
             output += "\n"
         return output
 
@@ -203,9 +200,8 @@ class NetworkInterfacesAdapter:
                 iface["options"]["bitrate"] = int(iface["options"]["bitrate"])
 
         if "hwaddress" in iface["options"]:
-            hwaddress_value = iface["options"]["hwaddress"]
-            if hwaddress_value.startswith("ether"):
-                iface["options"]["hwaddress"] = hwaddress_value[5:].strip()
+            # strip deprecated class attribute
+            iface["options"]["hwaddress"] = iface["options"]["hwaddress"].strip().split(" ")[-1]
 
     def get_interfaces(self):
         """


### PR DESCRIPTION
  * Fix parsing of hwaddress
  * Fix filtering interfaces without type

Корректный формат для `hwaddress` это `hwaddress class addr`. Наш парсер не расчитывал, что есть `class`, и посылал всю строку в wb-mqtt-confed. Тот валидировал параметр по схеме, а в схеме у нас прописан регэксп на mac-адрес. Валидация проваливалась, и в веб-интерфейсе выводилась ошибка `invalid config file`.

Если в /etc/network/interfaces есть параметр без типа, то в парсере не формировался параметр `options`, при этом мы безусловно считали, что он есть, и обращались к нему через `["options"]`, на что получали питоновское исключение, весь процесс разбора конфига валился, и пользователь видел в веб-интерфейсе `invalid config file`.