### PR TITLE
Fix SIM switching when several modems are available

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.31.3) stable; urgency=medium
+
+  * Fix SIM switching when several modems are available
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 12 Dec 2023 18:16:54 +0500
+
 wb-nm-helper (1.31.2) stable; urgency=medium
 
   * Tests cleanup. No functional changes

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -1141,60 +1141,60 @@ class ConnectionManagerTests(TestCase):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
         dev.get_property.return_value = "DUMMY_UDI"
-        DummyModem = MagicMock()
-        DummyModem.get_primary_sim_slot = MagicMock(return_value=1)
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_primary_sim_slot = MagicMock(return_value=1)
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
         self.con_man.change_modem_sim_slot = MagicMock()
 
         with patch.object(connection_manager, "NM_SETTINGS_GSM_SIM_SLOT_DEFAULT", 31337), patch.object(
-            connection_manager, "MMModem", DummyModemInit
+            connection_manager, "MMModem", dummy_modem_init
         ):
             result = self.con_man.apply_sim_slot(dev, con, 31337)
 
         self.assertEqual(dev, result)
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_UDI", self.bus)
-        self.assertEqual([call()], DummyModem.get_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_called_once_with("DUMMY_UDI", self.bus)
+        self.assertEqual([call()], dummy_modem.get_primary_sim_slot.mock_calls)
         self.assertEqual([], self.con_man.change_modem_sim_slot.mock_calls)
 
     def test_apply_sim_slot_02_current_slot(self):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
         dev.get_property.return_value = "DUMMY_UDI"
-        DummyModem = MagicMock()
-        DummyModem.get_primary_sim_slot = MagicMock(return_value=1)
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_primary_sim_slot = MagicMock(return_value=1)
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
         self.con_man.change_modem_sim_slot = MagicMock()
 
         with patch.object(connection_manager, "NM_SETTINGS_GSM_SIM_SLOT_DEFAULT", 31337), patch.object(
-            connection_manager, "MMModem", DummyModemInit
+            connection_manager, "MMModem", dummy_modem_init
         ):
             result = self.con_man.apply_sim_slot(dev, con, 1)
 
         self.assertEqual(dev, result)
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_UDI", self.bus)
-        self.assertEqual([call()], DummyModem.get_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_called_once_with("DUMMY_UDI", self.bus)
+        self.assertEqual([call()], dummy_modem.get_primary_sim_slot.mock_calls)
         self.assertEqual([], self.con_man.change_modem_sim_slot.mock_calls)
 
     def test_apply_sim_slot_03_different_slot(self):
         con = DummyNMConnection("con_id", {})
         dev = DummyNMDevice()
         dev.get_property.return_value = "DUMMY_UDI"
-        DummyModem = MagicMock()
-        DummyModem.get_primary_sim_slot = MagicMock(return_value=1)
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_primary_sim_slot = MagicMock(return_value=1)
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
         self.con_man.change_modem_sim_slot = MagicMock(return_value="CHANGE_RESULT")
 
         with patch.object(connection_manager, "NM_SETTINGS_GSM_SIM_SLOT_DEFAULT", 31337), patch.object(
-            connection_manager, "MMModem", DummyModemInit
+            connection_manager, "MMModem", dummy_modem_init
         ):
             result = self.con_man.apply_sim_slot(dev, con, 2)
 
         self.assertEqual("CHANGE_RESULT", result)
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_UDI", self.bus)
-        self.assertEqual([call()], DummyModem.get_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_called_once_with("DUMMY_UDI", self.bus)
+        self.assertEqual([call()], dummy_modem.get_primary_sim_slot.mock_calls)
         self.assertEqual([call(dev, con, 2)], self.con_man.change_modem_sim_slot.mock_calls)
 
     def test_activate_gsm_connection_01_no_active_cn_sim_not_applied(self):
@@ -1349,18 +1349,18 @@ class ConnectionManagerTests(TestCase):
         dev = DummyNMDevice()
         dev.get_property = MagicMock(return_value="DUMMY_PATH")
         self.con_man._wait_gsm_sim_slot_to_change = MagicMock(return_value=None)
-        DummyModem = MagicMock()
-        DummyModem.get_id = MagicMock(return_value="AAA")
-        DummyModem.set_primary_sim_slot = MagicMock()
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_id = MagicMock(return_value="AAA")
+        dummy_modem.set_primary_sim_slot = MagicMock()
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
 
-        with patch.object(connection_manager, "MMModem", DummyModemInit):
+        with patch.object(connection_manager, "MMModem", dummy_modem_init):
             result = self.con_man.change_modem_sim_slot(dev, "DUMMY_CON", 2)
 
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_PATH", self.bus)
-        self.assertEqual([call()], DummyModem.get_id.mock_calls)
-        self.assertEqual([call(2)], DummyModem.set_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_called_once_with("DUMMY_PATH", self.bus)
+        self.assertEqual([call()], dummy_modem.get_id.mock_calls)
+        self.assertEqual([call(2)], dummy_modem.set_primary_sim_slot.mock_calls)
         self.assertEqual(
             [call("AAA", "DUMMY_CON", "2", self.con_man.timeouts.connection_activation_timeout)],
             self.con_man._wait_gsm_sim_slot_to_change.mock_calls,
@@ -1371,18 +1371,18 @@ class ConnectionManagerTests(TestCase):
         dev = DummyNMDevice()
         dev.get_property = MagicMock(return_value="DUMMY_PATH")
         self.con_man._wait_gsm_sim_slot_to_change = MagicMock(return_value="DUMMY_DEV")
-        DummyModem = MagicMock()
-        DummyModem.get_id = MagicMock(return_value="AAA")
-        DummyModem.set_primary_sim_slot = MagicMock()
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_id = MagicMock(return_value="AAA")
+        dummy_modem.set_primary_sim_slot = MagicMock()
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
 
-        with patch.object(connection_manager, "MMModem", DummyModemInit):
+        with patch.object(connection_manager, "MMModem", dummy_modem_init):
             result = self.con_man.change_modem_sim_slot(dev, "DUMMY_CON", 2)
 
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_PATH", self.bus)
-        self.assertEqual([call()], DummyModem.get_id.mock_calls)
-        self.assertEqual([call(2)], DummyModem.set_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_called_once_with("DUMMY_PATH", self.bus)
+        self.assertEqual([call()], dummy_modem.get_id.mock_calls)
+        self.assertEqual([call(2)], dummy_modem.set_primary_sim_slot.mock_calls)
         self.assertEqual(
             [call("AAA", "DUMMY_CON", "2", self.con_man.timeouts.connection_activation_timeout)],
             self.con_man._wait_gsm_sim_slot_to_change.mock_calls,
@@ -1441,24 +1441,24 @@ class ConnectionManagerTests(TestCase):
         dev.get_property = MagicMock(return_value="DUMMY_PATH")
         self.con_man.now = MagicMock(side_effect=[now, now + step, now + timeout + step])
         self.con_man.network_manager.find_devices_for_connection = MagicMock(return_value=[dev])
-        DummyModem = MagicMock()
-        DummyModem.get_primary_sim_slot = MagicMock(return_value=1)
-        DummyModem.get_id = MagicMock(return_value="Modem1")
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_primary_sim_slot = MagicMock(return_value=1)
+        dummy_modem.get_id = MagicMock(return_value="Modem1")
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
 
         with patch.object(time, "sleep") as mock_sleep, patch.object(
-            connection_manager, "MMModem", DummyModemInit
+            connection_manager, "MMModem", dummy_modem_init
         ):
             result = self.con_man._wait_gsm_sim_slot_to_change("Modem1", "DUMMY_CON", "2", timeout)
 
         self.assertEqual([call(1)], mock_sleep.mock_calls)
         self.assertEqual([call("Udi")], dev.get_property.mock_calls)
-        DummyModemInit.assert_called_once_with("DUMMY_PATH", self.bus)
+        dummy_modem_init.assert_called_once_with("DUMMY_PATH", self.bus)
         self.assertEqual([call(), call(), call()], self.con_man.now.mock_calls)
         self.assertEqual(
             [call("DUMMY_CON")], self.con_man.network_manager.find_devices_for_connection.mock_calls
         )
-        self.assertEqual([call()], DummyModem.get_primary_sim_slot.mock_calls)
+        self.assertEqual([call()], dummy_modem.get_primary_sim_slot.mock_calls)
         self.assertEqual(None, result)
 
     def test_wait_gsm_sim_slot_to_change_02_no_dev_then_exception_then_same_slot_then_success(self):
@@ -1479,13 +1479,13 @@ class ConnectionManagerTests(TestCase):
         self.con_man.network_manager.find_devices_for_connection = MagicMock(
             side_effect=[[], dbus.exceptions.DBusException(), [dev], [dev]]
         )
-        DummyModem = MagicMock()
-        DummyModem.get_primary_sim_slot = MagicMock(side_effect=["1", "2"])
-        DummyModem.get_id = MagicMock(return_value="Modem1")
-        DummyModemInit = MagicMock(return_value=DummyModem)
+        dummy_modem = MagicMock()
+        dummy_modem.get_primary_sim_slot = MagicMock(side_effect=["1", "2"])
+        dummy_modem.get_id = MagicMock(return_value="Modem1")
+        dummy_modem_init = MagicMock(return_value=dummy_modem)
 
         with patch.object(time, "sleep") as mock_sleep, patch.object(
-            connection_manager, "MMModem", DummyModemInit
+            connection_manager, "MMModem", dummy_modem_init
         ):
             result = self.con_man._wait_gsm_sim_slot_to_change("Modem1", "DUMMY_CON", "2", timeout)
 
@@ -1496,8 +1496,8 @@ class ConnectionManagerTests(TestCase):
             [call("DUMMY_CON"), call("DUMMY_CON"), call("DUMMY_CON"), call("DUMMY_CON")],
             self.con_man.network_manager.find_devices_for_connection.mock_calls,
         )
-        self.assertEqual([call(), call()], DummyModem.get_primary_sim_slot.mock_calls)
-        DummyModemInit.assert_has_calls([call("OLD_PATH", self.bus), call("NEW_PATH", self.bus)])
+        self.assertEqual([call(), call()], dummy_modem.get_primary_sim_slot.mock_calls)
+        dummy_modem_init.assert_has_calls([call("OLD_PATH", self.bus), call("NEW_PATH", self.bus)])
         self.assertEqual(dev, result)
 
     def test_wait_connection_activation_01_instant_success(self):

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -8,12 +8,11 @@ import time
 from typing import Dict, Iterator, List, Optional
 
 import dbus
-from dbus import DBusException
 
 from wb.nm_helper.connection_checker import ConnectionChecker
 from wb.nm_helper.dns_resolver import resolve_domain_name
 from wb.nm_helper.logging_filter import ConnectionStateFilter
-from wb.nm_helper.modem_manager import ModemManager
+from wb.nm_helper.modem_manager import MMModem
 from wb.nm_helper.network_manager import (
     NM_ACTIVE_CONNECTION_STATE_ACTIVATED,
     NM_ACTIVE_CONNECTION_STATE_DEACTIVATED,
@@ -294,10 +293,10 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         self,
         network_manager: NetworkManager,
         config: NetworkAwareConfigFile,
-        modem_manager: ModemManager,
+        bus: dbus.SystemBus,
     ) -> None:
         self.network_manager: NetworkManager = network_manager
-        self.modem_manager: ModemManager = modem_manager
+        self.bus: dbus.SystemBus = bus
         self.config: NetworkAwareConfigFile = config
         self.timeouts: TimeoutManager = TimeoutManager(config)
         self.current_tier: Optional[ConnectionTier] = None
@@ -487,7 +486,8 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         dev_path = dev.get_property("Udi")
         logging.debug('Device path "%s"', dev_path)
         logging.debug("SIM slot for connection %s is %s", con.get_connection_id(), sim_slot)
-        current_sim_slot = self.modem_manager.get_primary_sim_slot(dev_path)
+        modem = MMModem(dev_path, self.bus)
+        current_sim_slot = modem.get_primary_sim_slot()
         logging.debug("Current SIM slot: %s, new SIM slot: %s", str(current_sim_slot), str(sim_slot))
         if sim_slot in (NM_SETTINGS_GSM_SIM_SLOT_DEFAULT, current_sim_slot):
             logging.debug("No need to change SIM slot")
@@ -537,11 +537,11 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
 
     def change_modem_sim_slot(self, dev: NMDevice, con: NMConnection, sim_slot: str) -> Optional[NMDevice]:
         dev_path = dev.get_property("Udi")
-        if not self.modem_manager.set_primary_sim_slot(dev_path, sim_slot):
-            logging.debug("It seems that SIM slot was not changed by MM")
-            return None
+        modem = MMModem(dev_path, self.bus)
+        modem_id = modem.get_id()
+        modem.set_primary_sim_slot(sim_slot)
         # After switching SIM card MM recreates device with new path
-        dev = self._wait_gsm_sim_slot_to_change(con, str(sim_slot), DEVICE_WAITING_TIMEOUT)
+        dev = self._wait_gsm_sim_slot_to_change(modem_id, con, str(sim_slot), DEVICE_WAITING_TIMEOUT)
         if not dev:
             logging.debug("Failed to get new device after changing SIM slot")
         return dev
@@ -560,22 +560,26 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         else:
             logging.debug("We deactivated non-current connection")
 
+    def _is_modem_with_changed_slot(self, device: NMDevice, modem_id: str, sim_slot: str) -> bool:
+        try:
+            modem = MMModem(device.get_property("Udi"), self.bus)
+            return modem_id == modem.get_id() and str(sim_slot) == str(modem.get_primary_sim_slot())
+        except dbus.exceptions.DBusException as ex:
+            # Some exceptions can be raised during waiting, because MM and NM remove and create devices
+            logging.debug("Error during device waiting: %s", ex)
+        return False
+
     def _wait_gsm_sim_slot_to_change(
-        self, con: NMConnection, sim_slot: str, timeout: datetime.timedelta
+        self, modem_id: str, con: NMConnection, sim_slot: str, timeout: datetime.timedelta
     ) -> Optional[NMDevice]:
         logging.debug("Waiting for SIM slot to change")
         start = self.now()
         while start + timeout >= self.now():
             try:
-                dev = self.network_manager.find_device_for_connection(con)
-                if not dev:
-                    continue
-                dev_path = dev.get_property("Udi")
-                current_sim_slot = self.modem_manager.get_primary_sim_slot(dev_path)
-                logging.debug("Current sim slot: %s", current_sim_slot)
-                if str(sim_slot) == str(current_sim_slot):
-                    logging.info("Changed SIM slot to %s to check connectivity", sim_slot)
-                    return dev
+                for device in self.network_manager.find_devices_for_connection(con):
+                    if self._is_modem_with_changed_slot(device, modem_id, sim_slot):
+                        logging.info("Changed SIM slot to %s to check connectivity", sim_slot)
+                        return device
             except dbus.exceptions.DBusException as ex:
                 # Some exceptions can be raised during waiting, because MM and NM remove and create devices
                 logging.debug("Error during device waiting: %s", ex)
@@ -765,15 +769,7 @@ def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     if config.has_connections():
-        try:
-            modem_manager = ModemManager()
-        except DBusException as ex:
-            modem_manager = None
-            logging.warning("Unable to initialize ModemManager, GSM connections will be unavailable (%s)", ex)
-
-        manager = ConnectionManager(
-            network_manager=network_manager, config=config, modem_manager=modem_manager
-        )
+        manager = ConnectionManager(network_manager=network_manager, config=config, bus=bus)
         while True:
             manager.cycle_loop()
             time.sleep(CHECK_PERIOD.total_seconds())

--- a/wb/nm_helper/network_manager.py
+++ b/wb/nm_helper/network_manager.py
@@ -111,6 +111,19 @@ class NetworkManager(NMObject):
             value = connection_type_to_device_type(settings["connection"]["type"])
         return self.find_device_by_param(param, value)
 
+    def find_devices_for_connection(self, cn_obj: NMConnection) -> List[NMDevice]:
+        settings = cn_obj.get_settings()
+        value = settings["connection"].get("interface-name", "")
+        if value:
+            device = self.find_device_by_param("Interface", value)
+            return [device] if device else []
+        res = []
+        value = connection_type_to_device_type(settings["connection"]["type"])
+        for device in self.get_devices():
+            if device.get_property("DeviceType") == value:
+                res.append(device)
+        return res
+
     def deactivate_connection(self, con: NMActiveConnection) -> None:
         self.get_iface().DeactivateConnection(con.get_object())
 


### PR DESCRIPTION
При переключении симкарты модем исчезает из dbus и появляется снова с новым путём. Наш старый код в цикле смотрел первый попавшийся модем и проверял, что у него выбран нужный сим-слот. Теперь перед переключением запоминаем уникальный идентификатор модема и ждём его появления после переключения симки.

Заодно убрал проверку доступности ModemManager при старте. Всё проверяется только, когда надо переключить симку