### PR TITLE
Reactivate connection if settings update failed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.32.1) stable; urgency=medium
+
+  * Reactivate connection if settings update failed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 19 Jan 2024 10:14:43 +0500
+
 wb-nm-helper (1.32.0) stable; urgency=medium
 
   * Add Wi-Fi AP band and channel configuration 

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -507,12 +507,18 @@ def apply(iface, c_handler, network_manager: NetworkManager, dry_run: bool) -> N
         return
     c_handler.set_dbus_options(dbus_settings, json_settings)
     reactivate = deactivate_connection(network_manager, con)
-    con.update_settings(dbus_settings.params)
+    update_exception = None
+    try:
+        con.update_settings(dbus_settings.params)
+    except dbus.exceptions.DBusException as ex:
+        update_exception = ex
     if reactivate:
         try:
             network_manager.activate_connection(con, None)
         except dbus.exceptions.DBusException:
             pass
+    if update_exception is not None:
+        raise update_exception
 
 
 class NetworkManagerAdapter:


### PR DESCRIPTION
Если в процессе обновления настроек произошла ошибка, ранее активное соединение остенется деактивированным. Активируем его снова, при ошибке