### PR TITLE
Fix connection settings updating error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.1) stable; urgency=medium
+
+  * Fix connection settings updating error 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 19 Feb 2024 10:52:12 +0500
+
 wb-nm-helper (1.33.0) stable; urgency=medium
 
   * Add GSM username and password configuration

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -279,7 +279,7 @@ class Connection:
         self.params = connection_params + additional_params
 
     def set_dbus_options(self, con: DBUSSettings, iface: JSONSettings) -> SetDbusOptionsResult:
-        res = copy.deepcopy(con)
+        res = DBUSSettings(con.params.copy())
         res.set_opts(iface, self.params)
         set_ipv4_dbus_options(res, iface)
         return SetDbusOptionsResult(res, False)

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import datetime
 import json
 import time


### PR DESCRIPTION
copy.deepcopy do not copy signature of dbus objects, so use dbus.Dictionary copy


Сломалось изменение настроек. Оно делается через запрос текущих настроек и применение к ним изменений. Раньше всё делалось на одном объекте. Теперь для красоты кода сделали копирование и возврат изменённого объекта. К сожалению, deepcopy не копирует артибуты объектов dbus, в частности signature. Из-за этого всё ломается. Сделал копирование через метод copy у dbus.Dictionary.