### PR TITLE
Do not check connectivity for bridge and tun

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.3) stable; urgency=medium
+
+  * Do not check connectivity for bridge and tun
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 03 May 2024 09:06:53 +0500
+
 wb-nm-helper (1.33.2) stable; urgency=medium
 
   * Fix connection settings updating error

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -27,12 +27,13 @@ from wb.nm_helper.network_manager import NMActiveConnection
 CONNECTIVITY_CHECK_PERIOD = 20
 MQTT_DRIVER_NAME = "wb-nm-helper"
 MQTT_DEVICE_TOPIC_PREFIX = "system__networks__"
+PERMANENT_CONNECTED_TYPES = ["loopback", "bridge", "tun"]
 
 
 def has_permanent_connectivity(active_connection: NMActiveConnection) -> bool:
     try:
         settings = active_connection.get_connection().get_settings()
-        if settings["connection"]["type"] == "loopback":
+        if settings["connection"]["type"] in PERMANENT_CONNECTED_TYPES:
             return True
         if settings.get("802-11-wireless", {}).get("mode") == "ap":
             return True


### PR DESCRIPTION
Мы не умеем их настраивать и отображать в web-интерфейсе, зачем нам пытаться проверять через них доступность интернета? Зато отладочные логи эти проверки забивают