### PR TITLE
Fix pylint

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+wb-nm-helper (1.33.6) stable; urgency=medium
+
+  * Fix pylint, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 20 Jun 2024 19:00:00 +0400
+
 wb-nm-helper (1.33.5) stable; urgency=medium
 
   * Add GSM pin and mtu configuration
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 02 May 2024 16:00:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 18 Jun 2024 16:00:00 +0400
 
 wb-nm-helper (1.33.4) stable; urgency=medium
 

--- a/wb/nm_helper/modem_manager.py
+++ b/wb/nm_helper/modem_manager.py
@@ -1,12 +1,11 @@
 import dbus
 
-from wb.nm_helper.network_manager import NMObject
+from wb.nm_helper.network_manager import DbusObject
 
 
-class MMObject(NMObject):
+class MMObject(DbusObject):
     def __init__(self, path: str, bus: dbus.SystemBus, interface_name: str):
-        NMObject.__init__(self, path, bus, interface_name)
-        self.dbus_name = "org.freedesktop.ModemManager1"
+        DbusObject.__init__(self, path, bus, interface_name, "org.freedesktop.ModemManager1")
 
 
 class MMModem(MMObject):

--- a/wb/nm_helper/modem_manager.py
+++ b/wb/nm_helper/modem_manager.py
@@ -1,35 +1,12 @@
 import dbus
 
+from wb.nm_helper.network_manager import NMObject
 
-class MMObject:
+
+class MMObject(NMObject):
     def __init__(self, path: str, bus: dbus.SystemBus, interface_name: str):
-        self.path = path
-        self.bus = bus
-        self.interface_name = interface_name
-        self.obj = None
-        self.iface = None
-        self.prop_iface = None
-
-    def get_object(self):
-        if self.obj is None:
-            self.obj = self.bus.get_object("org.freedesktop.ModemManager1", self.path)
-        return self.obj
-
-    def get_iface(self):
-        if self.iface is None:
-            self.iface = dbus.Interface(self.get_object(), self.interface_name)
-        return self.iface
-
-    def get_prop_iface(self):
-        if self.prop_iface is None:
-            self.prop_iface = dbus.Interface(self.get_object(), "org.freedesktop.DBus.Properties")
-        return self.prop_iface
-
-    def get_property(self, property_name: str):
-        return self.get_prop_iface().Get(self.interface_name, property_name)
-
-    def get_path(self) -> str:
-        return self.path
+        NMObject.__init__(self, path, bus, interface_name)
+        self.dbus_name = "org.freedesktop.ModemManager1"
 
 
 class MMModem(MMObject):

--- a/wb/nm_helper/network_manager.py
+++ b/wb/nm_helper/network_manager.py
@@ -50,10 +50,11 @@ class NMObject:
         self.obj = None
         self.iface = None
         self.prop_iface = None
+        self.dbus_name = "org.freedesktop.NetworkManager"
 
     def get_object(self):
         if self.obj is None:
-            self.obj = self.bus.get_object("org.freedesktop.NetworkManager", self.path)
+            self.obj = self.bus.get_object(self.dbus_name, self.path)
         return self.obj
 
     def get_iface(self):
@@ -69,7 +70,7 @@ class NMObject:
     def get_property(self, property_name: str):
         return self.get_prop_iface().Get(self.interface_name, property_name)
 
-    def get_path(self):
+    def get_path(self) -> str:
         return self.path
 
 

--- a/wb/nm_helper/network_manager.py
+++ b/wb/nm_helper/network_manager.py
@@ -42,15 +42,15 @@ def connection_type_to_device_type(cn_type):
     return types.get(cn_type, 0)
 
 
-class NMObject:
-    def __init__(self, path: str, bus: dbus.SystemBus, interface_name: str):
+class DbusObject:
+    def __init__(self, path: str, bus: dbus.SystemBus, interface_name: str, dbus_name: str):
         self.path = path
         self.bus = bus
         self.interface_name = interface_name
         self.obj = None
         self.iface = None
         self.prop_iface = None
-        self.dbus_name = "org.freedesktop.NetworkManager"
+        self.dbus_name = dbus_name
 
     def get_object(self):
         if self.obj is None:
@@ -72,6 +72,11 @@ class NMObject:
 
     def get_path(self) -> str:
         return self.path
+
+
+class NMObject(DbusObject):
+    def __init__(self, path: str, bus: dbus.SystemBus, interface_name: str):
+        DbusObject.__init__(self, path, bus, interface_name, "org.freedesktop.NetworkManager")
 
 
 class NetworkManager(NMObject):


### PR DESCRIPTION
Сейчас pylint без причины спотыкается на `from_json`:
```sh
Exception on node <FunctionDef.from_json l.111 at 0x7fe30dc3d7c0> in file '/home/jenkins/builder/workspace/wirenboard_wb-nm-helper_main/project/wb/nm_helper/nm_helper.py'
Traceback (most recent call last):
<...>
  File "/usr/local/lib/python3.9/dist-packages/pylint/checkers/refactoring/refactoring_checker.py", line 2057, in _is_function_def_never_returning
    if isinstance(node, (nodes.FunctionDef, astroid.BoundMethod)) and node.returns:
  File "/usr/local/lib/python3.9/dist-packages/astroid/bases.py", line 138, in __getattr__
    return getattr(self._proxied, name)
AttributeError: 'Lambda' object has no attribute 'returns'
```
То же самое и на последней версии pylint и astroid, похоже бага не исправлена. Но лечится небольшим рефакторингом.