### PR TITLE
Add wb-mqtt-nm-helper unit tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.7) stable; urgency=medium
+
+  * Add unit tests for wb-mqtt-nm-helper
+
+ --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 05 Aug 2024 14:29:11 +0300
+
 wb-nm-helper (1.33.6) stable; urgency=medium
 
   * Fix pylint, no functional changes

--- a/tests/connections_settings.py
+++ b/tests/connections_settings.py
@@ -1,0 +1,131 @@
+import dbus
+
+ETH0_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "id": dbus.String("wb-eth0", variant_level=1),
+                "interface-name": dbus.String("eth0", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("91f1c71d-2d97-4675-886f-ecbe52b8451e", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+ETH1_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "id": dbus.String("wb-eth1", variant_level=1),
+                "interface-name": dbus.String("eth1", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("c3e38405-9c17-4155-ad70-664311b49066", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+GSM_SIM1_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "autoconnect": dbus.Boolean(False, variant_level=1),
+                "id": dbus.String("wb-gsm-sim1", variant_level=1),
+                "type": "gsm",
+                "uuid": dbus.String("5d4297ba-c319-4c05-a153-17cb42e6e196", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "gsm": dbus.Dictionary(
+            {
+                "auto-config": dbus.Boolean(True, variant_level=1),
+                "sim-slot": dbus.Int32(1, variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+GSM_SIM2_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "autoconnect": dbus.Boolean(False, variant_level=1),
+                "id": dbus.String("wb-gsm-sim2", variant_level=1),
+                "type": "gsm",
+                "uuid": dbus.String("8b9964d4-b8dd-34d3-a3ed-481840bcf8c9", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "gsm": dbus.Dictionary(
+            {
+                "auto-config": dbus.Boolean(True, variant_level=1),
+                "sim-slot": dbus.Int32(2, variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+WB_AP_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "id": dbus.String("wb-ap", variant_level=1),
+                "interface-name": dbus.String("wlan0", variant_level=1),
+                "type": "802-11-wireless",
+                "uuid": dbus.String("d12c8d3c-1abe-4832-9b71-4ed6e3c20885", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "802-11-wireless": dbus.Dictionary(
+            {
+                "mode": dbus.String("ap", variant_level=1),
+                "ssid": dbus.ByteArray(bytes("WirenBoard-Тест", encoding="utf8")),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {
+                "address-data": dbus.Array(
+                    [
+                        dbus.Dictionary(
+                            {
+                                "address": dbus.String("192.168.42.1", variant_level=1),
+                                "prefix": dbus.Int32(24, variant_level=1),
+                            },
+                            signature=dbus.Signature("sv"),
+                        )
+                    ],
+                    signature=dbus.Signature("a{sv}"),
+                ),
+                "method": dbus.String("shared", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)

--- a/tests/mqtt_publications.py
+++ b/tests/mqtt_publications.py
@@ -1,0 +1,164 @@
+CONNECTIONS_INIT_PUBLICATIONS = [
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/meta/name",
+        "Network Connection wb-eth0",
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/meta/driver", "wb-nm-helper"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Name/meta",
+        '{"type": "text", "readonly": true, "order": 1}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Name", "wb-eth0"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UUID/meta",
+        '{"type": "text", "readonly": true, "order": 2}',
+    ),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UUID",
+        "91f1c71d-2d97-4675-886f-ecbe52b8451e",
+    ),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Type/meta",
+        '{"type": "text", "readonly": true, "order": 3}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Type", "802-3-ethernet"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active/meta",
+        '{"type": "switch", "readonly": true, "order": 4}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active", "0"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Device/meta",
+        '{"type": "text", "readonly": true, "order": 5}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Device", ""),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State/meta",
+        '{"type": "text", "readonly": true, "order": 6}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State", "deactivated"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Address/meta",
+        '{"type": "text", "readonly": true, "order": 7}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Address", ""),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Connectivity/meta",
+        '{"type": "switch", "readonly": true, "order": 8}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Connectivity", "0"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UpDown/meta",
+        '{"type": "pushbutton", "readonly": false, "title": {"en": "Up"}, "order": 12}',
+    ),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/meta/name",
+        "Network Connection wb-eth1",
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/meta/driver", "wb-nm-helper"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Name/meta",
+        '{"type": "text", "readonly": true, "order": 1}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Name", "wb-eth1"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UUID/meta",
+        '{"type": "text", "readonly": true, "order": 2}',
+    ),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UUID",
+        "c3e38405-9c17-4155-ad70-664311b49066",
+    ),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Type/meta",
+        '{"type": "text", "readonly": true, "order": 3}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Type", "802-3-ethernet"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Active/meta",
+        '{"type": "switch", "readonly": true, "order": 4}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Active", "0"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Device/meta",
+        '{"type": "text", "readonly": true, "order": 5}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Device", ""),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/State/meta",
+        '{"type": "text", "readonly": true, "order": 6}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/State", "deactivated"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Address/meta",
+        '{"type": "text", "readonly": true, "order": 7}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Address", ""),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Connectivity/meta",
+        '{"type": "switch", "readonly": true, "order": 8}',
+    ),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Connectivity", "0"),
+    (
+        "/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UpDown/meta",
+        '{"type": "pushbutton", "readonly": false, "title": {"en": "Up"}, "order": 12}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active", "1"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UpDown/meta",
+        '{"type": "pushbutton", "readonly": false, "title": {"en": "Down"}, "order": 12}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State", "activated"),
+]
+
+ACTIVE_CONNECTION_DELETE_PUBLICATIONS = [
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active", "0"),
+    (
+        "/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UpDown/meta",
+        '{"type": "pushbutton", "readonly": false, "title": {"en": "Up"}, "order": 12}',
+    ),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State", "deactivated"),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/meta/driver", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/meta/name", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Name", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Name/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UUID", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UUID/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Type", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Type/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Active/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Device", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Device/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/State/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Address", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Address/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Connectivity", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/Connectivity/meta", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UpDown", None),
+    ("/devices/system__networks__91f1c71d-2d97-4675-886f-ecbe52b8451e/controls/UpDown/meta", None),
+]
+
+NON_ACTIVE_CONNECTION_DELETE_PUBLICATIONS = [
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/meta/driver", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/meta/name", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Name", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Name/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UUID", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UUID/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Type", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Type/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Active", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Active/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Device", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Device/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/State", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/State/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Address", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Address/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Connectivity", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/Connectivity/meta", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UpDown", None),
+    ("/devices/system__networks__c3e38405-9c17-4155-ad70-664311b49066/controls/UpDown/meta", None),
+]

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -73,7 +73,7 @@ class MQTTNetworkManagerTest(dbusmock.DBusTestCase):
         self.mediator = wb.nm_helper.virtual_devices.ConnectionsMediator(mqtt_mock)
         self.mediator.run()
 
-    def publish(self, topic, value, _retain):
+    def publish(self, topic, value, retain):  # pylint: disable=unused-argument
         self.mqtt_publications.append((topic, value))
 
     def tearDown(self):

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -73,7 +73,7 @@ class MQTTNetworkManagerTest(dbusmock.DBusTestCase):
         self.mediator = wb.nm_helper.virtual_devices.ConnectionsMediator(mqtt_mock)
         self.mediator.run()
 
-    def publish(self, topic, value, retain):  # pylint: disable=unused-argument
+    def publish(self, topic, value, _retain):
         self.mqtt_publications.append((topic, value))
 
     def tearDown(self):

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -1,0 +1,180 @@
+# from dbusmock.pytest_fixtures import dbusmock_system
+import subprocess
+import time
+import unittest
+from multiprocessing import Process
+from multiprocessing.managers import BaseManager
+from unittest.mock import Mock
+
+import dbus
+import dbus.mainloop.glib
+import dbusmock
+from dbusmock.templates.networkmanager import (
+    CSETTINGS_IFACE,
+    MANAGER_IFACE,
+    MANAGER_OBJ,
+    SETTINGS_IFACE,
+    SETTINGS_OBJ,
+    DeviceState,
+)
+from gi.repository import GLib
+from wb_common.mqtt_client import MQTTClient
+
+import wb.nm_helper.virtual_devices
+
+from . import mqtt_publications as publications
+
+ETH0_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "id": dbus.String("wb-eth0", variant_level=1),
+                "interface-name": dbus.String("eth0", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("91f1c71d-2d97-4675-886f-ecbe52b8451e", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+ETH1_DBUS_SETTINGS = dbus.Dictionary(
+    {
+        "connection": dbus.Dictionary(
+            {
+                "id": dbus.String("wb-eth1", variant_level=1),
+                "interface-name": dbus.String("eth1", variant_level=1),
+                "type": "802-3-ethernet",
+                "uuid": dbus.String("c3e38405-9c17-4155-ad70-664311b49066", variant_level=1),
+            },
+            signature=dbus.Signature("sv"),
+        ),
+        "ipv4": dbus.Dictionary(
+            {"method": dbus.String("auto", variant_level=1)},
+            signature=dbus.Signature("sv"),
+        ),
+    },
+    signature=dbus.Signature("sa{sv}"),
+)
+
+
+class MemoryManager(BaseManager):
+    pass
+
+
+class MQTTNetworkManagerTest(dbusmock.DBusTestCase):
+
+    def setUp(self):
+        self.start_system_bus()
+        self.system_bus = self.get_dbus(system_bus=True)
+
+        (self.p_mock, self.obj_networkmanager) = self.spawn_server_template(
+            "networkmanager",
+            {"NetworkingEnabled": True},
+            stdout=subprocess.PIPE,
+            system_bus=True,
+        )
+        self.networkmanager_mock = dbus.Interface(self.obj_networkmanager, dbusmock.MOCK_IFACE)
+        self.networkmanager = dbus.Interface(
+            self.system_bus.get_object(MANAGER_IFACE, MANAGER_OBJ), MANAGER_IFACE
+        )
+        self.settings = dbus.Interface(
+            self.system_bus.get_object(MANAGER_IFACE, SETTINGS_OBJ), SETTINGS_IFACE
+        )
+
+        self.connections = {}
+        self.connections.update({"eth0": self.settings.AddConnection(ETH0_DBUS_SETTINGS)})
+        self.connections.update({"eth1": self.settings.AddConnection(ETH1_DBUS_SETTINGS)})
+
+        self.devices = {}
+        self.devices.update(
+            {"eth0": self.networkmanager_mock.AddEthernetDevice("mock_eth0", "eth0", DeviceState.ACTIVATED)}
+        )
+
+        self.networkmanager.ActivateConnection(self.connections["eth0"], "/", "/")
+
+        MemoryManager.register("list", list)
+        self.manager = MemoryManager()
+        self.manager.start()
+
+        self.mqtt_publications = self.manager.list()
+
+        self.proc = Process(target=self.start_mediator)
+        self.proc.start()
+
+    def start_mediator(self):
+        self.mqtt_mock = Mock(MQTTClient)
+        self.mqtt_mock.publish.side_effect = self.publish
+
+        self.mediator = wb.nm_helper.virtual_devices.ConnectionsMediator(self.mqtt_mock)
+        self.mediator.run()
+
+    def publish(self, topic, value, retain):
+        self.mqtt_publications.append((topic, value))
+        print(f"('{topic}','{value}'),")
+
+    def tearDown(self):
+        self.proc.kill()
+        if self.p_mock:
+            self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+            self.p_mock = None
+
+    def wait_for(self, condition, timeout, poll_interval=0):
+        current_time = time.time()
+        while not condition():
+            if (time.time() - current_time) > timeout:
+                return False
+            time.sleep(poll_interval)
+        return True
+
+    def test_main(self):
+        self.assert_connections_init()
+        self.assert_delete_active_connection()
+        self.assert_delete_non_active_connection()
+
+    # check that the connection devices that were added before starting the service have been created
+    def assert_connections_init(self):
+        self.wait_for(
+            lambda: len(self.mqtt_publications._getvalue())
+            == len(publications.CONNECTIONS_INIT_PUBLICATIONS),
+            3,
+            1,
+        )
+        assert self.mqtt_publications._getvalue() == publications.CONNECTIONS_INIT_PUBLICATIONS
+
+    def assert_delete_active_connection(self):
+        self.mqtt_publications.clear()
+        connection = dbus.Interface(
+            self.system_bus.get_object(MANAGER_IFACE, self.connections["eth0"]), CSETTINGS_IFACE
+        )
+        connection.Delete()
+        self.connections.pop("eth0")
+        self.wait_for(
+            lambda: len(self.mqtt_publications._getvalue())
+            == len(publications.ACTIVE_CONNECTION_DELETE_PUBLICATIONS),
+            3,
+            1,
+        )
+        assert self.mqtt_publications._getvalue() == publications.ACTIVE_CONNECTION_DELETE_PUBLICATIONS
+
+    def assert_delete_non_active_connection(self):
+        self.mqtt_publications.clear()
+        connection = dbus.Interface(
+            self.system_bus.get_object(MANAGER_IFACE, self.connections["eth1"]), CSETTINGS_IFACE
+        )
+        connection.Delete()
+        self.connections.pop("eth1")
+        self.wait_for(
+            lambda: len(self.mqtt_publications._getvalue())
+            == len(publications.NON_ACTIVE_CONNECTION_DELETE_PUBLICATIONS),
+            3,
+            1,
+        )
+        assert self.mqtt_publications._getvalue() == publications.NON_ACTIVE_CONNECTION_DELETE_PUBLICATIONS

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -15,6 +15,8 @@ from dbusmock.templates.networkmanager import (
 
 from wb.nm_helper import nm_helper
 
+from . import connections_settings as connections
+
 
 class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
     @classmethod
@@ -39,145 +41,19 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
             self.p_mock = None
 
     def add_wb_eth0(self):
-        self.settings.AddConnection(
-            dbus.Dictionary(
-                {
-                    "connection": dbus.Dictionary(
-                        {
-                            "id": dbus.String("wb-eth0", variant_level=1),
-                            "interface-name": dbus.String("eth0", variant_level=1),
-                            "type": "802-3-ethernet",
-                            "uuid": dbus.String("91f1c71d-2d97-4675-886f-ecbe52b8451e", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "ipv4": dbus.Dictionary(
-                        {"method": dbus.String("auto", variant_level=1)}, signature=dbus.Signature("sv")
-                    ),
-                },
-                signature=dbus.Signature("sa{sv}"),
-            )
-        )
+        self.settings.AddConnection(connections.ETH0_DBUS_SETTINGS)
 
     def add_wb_eth1(self):
-        self.settings.AddConnection(
-            dbus.Dictionary(
-                {
-                    "connection": dbus.Dictionary(
-                        {
-                            "id": dbus.String("wb-eth1", variant_level=1),
-                            "interface-name": dbus.String("eth1", variant_level=1),
-                            "type": "802-3-ethernet",
-                            "uuid": dbus.String("c3e38405-9c17-4155-ad70-664311b49066", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "ipv4": dbus.Dictionary(
-                        {"method": dbus.String("auto", variant_level=1)}, signature=dbus.Signature("sv")
-                    ),
-                },
-                signature=dbus.Signature("sa{sv}"),
-            )
-        )
+        self.settings.AddConnection(connections.ETH1_DBUS_SETTINGS)
 
     def add_wb_gsm_sim1(self):
-        self.settings.AddConnection(
-            dbus.Dictionary(
-                {
-                    "connection": dbus.Dictionary(
-                        {
-                            "autoconnect": dbus.Boolean(False, variant_level=1),
-                            "id": dbus.String("wb-gsm-sim1", variant_level=1),
-                            "type": "gsm",
-                            "uuid": dbus.String("5d4297ba-c319-4c05-a153-17cb42e6e196", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "gsm": dbus.Dictionary(
-                        {
-                            "auto-config": dbus.Boolean(True, variant_level=1),
-                            "sim-slot": dbus.Int32(1, variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "ipv4": dbus.Dictionary(
-                        {"method": dbus.String("auto", variant_level=1)}, signature=dbus.Signature("sv")
-                    ),
-                },
-                signature=dbus.Signature("sa{sv}"),
-            )
-        )
+        self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
 
     def add_wb_gsm_sim2(self):
-        self.settings.AddConnection(
-            dbus.Dictionary(
-                {
-                    "connection": dbus.Dictionary(
-                        {
-                            "autoconnect": dbus.Boolean(False, variant_level=1),
-                            "id": dbus.String("wb-gsm-sim2", variant_level=1),
-                            "type": "gsm",
-                            "uuid": dbus.String("8b9964d4-b8dd-34d3-a3ed-481840bcf8c9", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "gsm": dbus.Dictionary(
-                        {
-                            "auto-config": dbus.Boolean(True, variant_level=1),
-                            "sim-slot": dbus.Int32(2, variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "ipv4": dbus.Dictionary(
-                        {"method": dbus.String("auto", variant_level=1)}, signature=dbus.Signature("sv")
-                    ),
-                },
-                signature=dbus.Signature("sa{sv}"),
-            )
-        )
+        self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
 
     def add_wb_ap(self):
-        self.settings.AddConnection(
-            dbus.Dictionary(
-                {
-                    "connection": dbus.Dictionary(
-                        {
-                            "id": dbus.String("wb-ap", variant_level=1),
-                            "interface-name": dbus.String("wlan0", variant_level=1),
-                            "type": "802-11-wireless",
-                            "uuid": dbus.String("d12c8d3c-1abe-4832-9b71-4ed6e3c20885", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "802-11-wireless": dbus.Dictionary(
-                        {
-                            "mode": dbus.String("ap", variant_level=1),
-                            "ssid": dbus.ByteArray(bytes("WirenBoard-Тест", encoding="utf8")),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                    "ipv4": dbus.Dictionary(
-                        {
-                            "address-data": dbus.Array(
-                                [
-                                    dbus.Dictionary(
-                                        {
-                                            "address": dbus.String("192.168.42.1", variant_level=1),
-                                            "prefix": dbus.Int32(24, variant_level=1),
-                                        },
-                                        signature=dbus.Signature("sv"),
-                                    )
-                                ],
-                                signature=dbus.Signature("a{sv}"),
-                            ),
-                            "method": dbus.String("shared", variant_level=1),
-                        },
-                        signature=dbus.Signature("sv"),
-                    ),
-                },
-                signature=dbus.Signature("sa{sv}"),
-            )
-        )
+        self.settings.AddConnection(connections.WB_AP_DBUS_SETTINGS)
 
     def test_to_json(self):
         # pylint: disable=R0915


### PR DESCRIPTION
Добавила юнит-тесты на удаление устройств. Проверила удаление нактивного и неактивного устройства
Публикатор работает на основе подписок на события. Библиотека dbus устроена так, что подписаться на события можно только с основном потоке выполнения. Поэтому в теле тестов созавать и запускать класс приходится в отдельном процессе, иначе не проверить что публикатор работает по событиям.
Юниттест не позволил запускать процесс из setUpClass, запуск процесса сработал только из обычного setUp, поэтому чтобы на каждый тест не запускать/останавливать публикатор, положила все тесты как вызовы в одну тестовую функцию.
Не очень нравится что все тесты получились в куче, если кто подскажет как обойти это - буду рада