### PR TITLE
Fix dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.8) stable; urgency=medium
+
+  * Fix dependencies, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 13 Aug 2024 13:50:00 +0400
+
 wb-nm-helper (1.33.7) stable; urgency=medium
 
   * Add unit tests for wb-mqtt-nm-helper

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: debhelper (>= 10),
                python3-tomli,
                python3-dbus,
                python3-dbusmock,
+               python3-gi,
                python3-jsonschema,
                python3-pyparsing,
                python3-pycurl,
@@ -27,8 +28,10 @@ Depends: ${python3:Depends},
          ${misc:Depends},
          python3-pyparsing,
          python3-dbus,
+         python3-gi,
          python3-pycurl,
-         python3-pycares
+         python3-pycares,
+         python3-wb-common (>= 2.1.1)
 Description: Wirenboard network configuration python3 library
  The package includes utility functions for wb-nm-helper.
 
@@ -39,7 +42,6 @@ Depends: ${misc:Depends},
          python3-wb-nm-helper (= ${binary:Version}),
          wb-mqtt-homeui (>= 2.56.0~~),
          wb-mqtt-confed (>= 1.13.0~~),
-         python3-wb-common (>= 2.1.1),
          network-manager,
          modemmanager,
          mobile-broadband-provider-info,


### PR DESCRIPTION
Follow up #54:
* python3-wb-nm-helper requires [python3-gi](https://packages.debian.org/bullseye/python3-gi): https://github.com/wirenboard/wb-nm-helper/blob/007eea004df56a1e141c3282151a690d73bd5134/wb/nm_helper/virtual_devices.py#L19
* python3-wb-nm-helper requires python3-wb-common: https://github.com/wirenboard/wb-nm-helper/blob/007eea004df56a1e141c3282151a690d73bd5134/wb/nm_helper/virtual_devices.py#L20