### PR TITLE
Fix gsm default connections deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .config
 .pylintrc
 .vscode
+.devcontainer

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.8) stable; urgency=medium
+
+  * Fix gsm default connection deletion on new settings saving when modem disabled
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 13 Aug 2024 17:52:32 +0300
+
 wb-nm-helper (1.33.7) stable; urgency=medium
 
   * Add unit tests for wb-mqtt-nm-helper

--- a/tests/data/ui_without_gsm.json
+++ b/tests/data/ui_without_gsm.json
@@ -1,0 +1,130 @@
+{
+  "data": {
+    "devices": [
+      {
+        "iface": "eth0",
+        "type": "ethernet"
+      },
+      {
+        "iface": "eth1",
+        "type": "ethernet"
+      },
+      {
+        "iface": "wlan0",
+        "type": "wifi"
+      },
+      {
+        "iface": "wlan1",
+        "type": "wifi"
+      }
+    ],
+    "ssids": []
+  },
+  "ui": {
+    "con_switch": {
+      "connections": [],
+      "debug": false
+    },
+    "connections": [
+      {
+        "connection_interface-name": "eth0",
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "01_nm_ethernet",
+        "connection_autoconnect": true,
+        "connection_id": "wb-eth0",
+        "connection_uuid": "91f1c71d-2d97-4675-886f-ecbe52b8451e"
+      },
+      {
+        "connection_interface-name": "eth1",
+        "ipv4": {
+          "dhcp-client-id": "",
+          "dhcp-hostname": "",
+          "method": "auto"
+        },
+        "type": "01_nm_ethernet",
+        "connection_autoconnect": true,
+        "connection_id": "wb-eth1",
+        "connection_uuid": "c3e38405-9c17-4155-ad70-664311b49066"
+      },
+      {
+        "802-11-wireless-security": {
+          "security": "none"
+        },
+        "802-11-wireless_mode": "ap",
+        "802-11-wireless_ssid": "WirenBoard-XXXXXXXX",
+        "connection_interface-name": "wlan0",
+        "ipv4": {
+          "address": "192.168.42.1",
+          "method": "shared",
+          "netmask": "255.255.255.0"
+        },
+        "type": "04_nm_wifi_ap",
+        "connection_autoconnect": true,
+        "connection_id": "wb-ap",
+        "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885"
+      },
+      {
+        "name": "can0",
+        "allow-hotplug": true,
+        "mode": "can",
+        "method": "static",
+        "type": "can",
+        "options": {
+          "bitrate": 125000
+        },
+        "auto": false
+      },
+      {
+        "name": "eth0",
+        "auto": true,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hostname": "WirenBoard",
+          "pre-up": ["wb-set-mac"]
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
+        "name": "eth1",
+        "auto": false,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hostname": "WirenBoard",
+          "pre-up": ["wb-set-mac # comment1", "sleep 10   # comment2", "#test"]
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
+        "name": "eth2",
+        "auto": false,
+        "mode": "inet",
+        "method": "dhcp",
+        "options": {
+          "hwaddress": "94:C6:91:91:4D:5A"
+        },
+        "allow-hotplug": true,
+        "type": "dhcp"
+      },
+      {
+        "name": "wlan0",
+        "auto": false,
+        "mode": "inet",
+        "method": "static",
+        "options": {
+          "address": "192.168.42.1",
+          "netmask": "255.255.255.0"
+        },
+        "allow-hotplug": true,
+        "type": "static"
+      }
+    ]
+  }
+}

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -21,8 +21,8 @@ from wb_common.mqtt_client import MQTTClient
 
 import wb.nm_helper.virtual_devices
 
-from . import connections_settings as connections
-from . import mqtt_publications as publications
+from tests import connections_settings as connections
+from tests import mqtt_publications as publications
 
 
 class MemoryManager(BaseManager):

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -9,9 +9,14 @@ from unittest.mock import Mock
 import dbus
 import dbus.mainloop.glib
 import dbusmock
-from dbusmock.templates.networkmanager import (CSETTINGS_IFACE, MANAGER_IFACE,
-                                               MANAGER_OBJ, SETTINGS_IFACE,
-                                               SETTINGS_OBJ, DeviceState)
+from dbusmock.templates.networkmanager import (
+    CSETTINGS_IFACE,
+    MANAGER_IFACE,
+    MANAGER_OBJ,
+    SETTINGS_IFACE,
+    SETTINGS_OBJ,
+    DeviceState,
+)
 from wb_common.mqtt_client import MQTTClient
 
 import wb.nm_helper.virtual_devices

--- a/tests/test_mqtt_nm_helper.py
+++ b/tests/test_mqtt_nm_helper.py
@@ -9,18 +9,12 @@ from unittest.mock import Mock
 import dbus
 import dbus.mainloop.glib
 import dbusmock
-from dbusmock.templates.networkmanager import (
-    CSETTINGS_IFACE,
-    MANAGER_IFACE,
-    MANAGER_OBJ,
-    SETTINGS_IFACE,
-    SETTINGS_OBJ,
-    DeviceState,
-)
+from dbusmock.templates.networkmanager import (CSETTINGS_IFACE, MANAGER_IFACE,
+                                               MANAGER_OBJ, SETTINGS_IFACE,
+                                               SETTINGS_OBJ, DeviceState)
 from wb_common.mqtt_client import MQTTClient
 
 import wb.nm_helper.virtual_devices
-
 from tests import connections_settings as connections
 from tests import mqtt_publications as publications
 

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -11,6 +11,7 @@ from dbusmock.templates.networkmanager import (
     SETTINGS_IFACE,
     SETTINGS_OBJ,
     DeviceState,
+    CSETTINGS_IFACE
 )
 
 from wb.nm_helper import nm_helper
@@ -40,20 +41,6 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
             self.p_mock.wait()
             self.p_mock = None
 
-    def add_wb_eth0(self):
-        self.settings.AddConnection(connections.ETH0_DBUS_SETTINGS)
-
-    def add_wb_eth1(self):
-        self.settings.AddConnection(connections.ETH1_DBUS_SETTINGS)
-
-    def add_wb_gsm_sim1(self):
-        self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
-
-    def add_wb_gsm_sim2(self):
-        self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
-
-    def add_wb_ap(self):
-        self.settings.AddConnection(connections.WB_AP_DBUS_SETTINGS)
 
     def test_to_json(self):
         # pylint: disable=R0915
@@ -65,11 +52,11 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         self.networkmanager_mock.AddWiFiDevice("mock_wlan0", "wlan0", DeviceState.ACTIVATED)
         self.networkmanager_mock.AddWiFiDevice("mock_wlan1", "wlan1", DeviceState.ACTIVATED)
 
-        self.add_wb_eth0()
-        self.add_wb_eth1()
-        self.add_wb_gsm_sim1()
-        self.add_wb_gsm_sim2()
-        self.add_wb_ap()
+        self.settings.AddConnection(connections.ETH0_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.ETH1_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.WB_AP_DBUS_SETTINGS)
 
         res = nm_helper.to_json(
             args=argparse.Namespace(
@@ -173,6 +160,49 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         assert res["ui"]["connections"][9]["name"] == "can0"
         assert res["ui"]["connections"][9]["options"]["bitrate"] == 125000
         assert res["ui"]["connections"][9]["type"] == "can"
+    
+    def _test_from_json_gsm_common(self, modem_enabled):
+        nm_helper.get_systemd_manager = Mock()
+        nm_helper.is_modem_enabled = Mock(return_value=modem_enabled)
+        
+        with open("tests/data/ui_without_gsm.json", "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+            
+        nm_helper.from_json(
+                cfg,
+                args=argparse.Namespace(
+                    interfaces_conf="tests/data/non-exist-file",
+                    dnsmasq_conf="tests/data/dnsmasq.conf",
+                    hostapd_conf="tests/data/hostapd.conf",
+                    dry_run=False,
+                ),
+            )
+        
+        new_connections = []
+        connections_paths = self.settings.ListConnections()
+        for connection_path in connections_paths:
+            connection = dbus.Interface(self.system_bus.get_object(MANAGER_IFACE, connection_path), CSETTINGS_IFACE)
+            settings = connection.GetSettings()
+            new_connections.append(settings["connection"]["id"])
+            
+        return new_connections   
+        
+    
+    def test_from_json_modem_en(self):
+        self.settings.AddConnection(connections.ETH0_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.ETH1_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
+              
+        new_connections = self._test_from_json_gsm_common(True)       
+        assert new_connections == ["wb-eth0","wb-eth1","wb-ap"]
+        
+    def test_from_json_modem_dis(self):
+        self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
+        self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
+              
+        new_connections = self._test_from_json_gsm_common(False)       
+        assert new_connections == ["wb-gsm-sim1","wb-gsm-sim2","wb-eth0","wb-eth1","wb-ap"]
 
 
 def test_from_json():

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -16,7 +16,7 @@ from dbusmock.templates.networkmanager import (
 
 from wb.nm_helper import nm_helper
 
-from . import connections_settings as connections
+from tests import connections_settings as connections
 
 
 class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -7,11 +7,11 @@ import dbus
 import dbusmock
 import jsonschema
 from dbusmock.templates.networkmanager import (
+    CSETTINGS_IFACE,
     MANAGER_IFACE,
     SETTINGS_IFACE,
     SETTINGS_OBJ,
     DeviceState,
-    CSETTINGS_IFACE
 )
 
 from wb.nm_helper import nm_helper
@@ -40,7 +40,6 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
             self.p_mock.terminate()
             self.p_mock.wait()
             self.p_mock = None
-
 
     def test_to_json(self):
         # pylint: disable=R0915
@@ -160,49 +159,50 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         assert res["ui"]["connections"][9]["name"] == "can0"
         assert res["ui"]["connections"][9]["options"]["bitrate"] == 125000
         assert res["ui"]["connections"][9]["type"] == "can"
-    
+
     def _test_from_json_gsm_common(self, modem_enabled):
         nm_helper.get_systemd_manager = Mock()
         nm_helper.is_modem_enabled = Mock(return_value=modem_enabled)
-        
+
         with open("tests/data/ui_without_gsm.json", "r", encoding="utf-8") as f:
             cfg = json.load(f)
-            
+
         nm_helper.from_json(
-                cfg,
-                args=argparse.Namespace(
-                    interfaces_conf="tests/data/non-exist-file",
-                    dnsmasq_conf="tests/data/dnsmasq.conf",
-                    hostapd_conf="tests/data/hostapd.conf",
-                    dry_run=False,
-                ),
-            )
-        
+            cfg,
+            args=argparse.Namespace(
+                interfaces_conf="tests/data/non-exist-file",
+                dnsmasq_conf="tests/data/dnsmasq.conf",
+                hostapd_conf="tests/data/hostapd.conf",
+                dry_run=False,
+            ),
+        )
+
         new_connections = []
         connections_paths = self.settings.ListConnections()
         for connection_path in connections_paths:
-            connection = dbus.Interface(self.system_bus.get_object(MANAGER_IFACE, connection_path), CSETTINGS_IFACE)
+            connection = dbus.Interface(
+                self.system_bus.get_object(MANAGER_IFACE, connection_path), CSETTINGS_IFACE
+            )
             settings = connection.GetSettings()
             new_connections.append(settings["connection"]["id"])
-            
-        return new_connections   
-        
-    
+
+        return new_connections
+
     def test_from_json_modem_en(self):
         self.settings.AddConnection(connections.ETH0_DBUS_SETTINGS)
         self.settings.AddConnection(connections.ETH1_DBUS_SETTINGS)
         self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
         self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
-              
-        new_connections = self._test_from_json_gsm_common(True)       
-        assert new_connections == ["wb-eth0","wb-eth1","wb-ap"]
-        
+
+        new_connections = self._test_from_json_gsm_common(True)
+        assert new_connections == ["wb-eth0", "wb-eth1", "wb-ap"]
+
     def test_from_json_modem_dis(self):
         self.settings.AddConnection(connections.GSM_SIM1_DBUS_SETTINGS)
         self.settings.AddConnection(connections.GSM_SIM2_DBUS_SETTINGS)
-              
-        new_connections = self._test_from_json_gsm_common(False)       
-        assert new_connections == ["wb-gsm-sim1","wb-gsm-sim2","wb-eth0","wb-eth1","wb-ap"]
+
+        new_connections = self._test_from_json_gsm_common(False)
+        assert new_connections == ["wb-gsm-sim1", "wb-gsm-sim2", "wb-eth0", "wb-eth1", "wb-ap"]
 
 
 def test_from_json():

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -14,9 +14,8 @@ from dbusmock.templates.networkmanager import (
     DeviceState,
 )
 
-from wb.nm_helper import nm_helper
-
 from tests import connections_settings as connections
+from wb.nm_helper import nm_helper
 
 
 class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -587,7 +587,7 @@ class NetworkManagerAdapter:
         }
         self.network_manager = NetworkManager()
 
-    def remove_undefined_connections(self, interfaces):
+    def remove_undefined_connections(self, interfaces, keep_masks: List):
         uids = []
         for iface in interfaces:
             settings = JSONSettings(iface)
@@ -596,14 +596,19 @@ class NetworkManagerAdapter:
                 uids.append(uuid)
         for con in self.network_manager.get_connections():
             c_settings = DBUSSettings(con.get_settings())
+
+            id = c_settings.get_opt("connection.id")
+            if any(mask in id for mask in keep_masks):
+                break
+
             for handler in self.handlers.values():
                 if (c_settings.get_opt("connection.uuid") not in uids) and handler.can_manage(c_settings):
                     con.delete()
                     break
 
-    def apply(self, interfaces, dry_run: bool) -> bool:
+    def apply(self, interfaces, dry_run: bool, keep_masks: List = []) -> bool:
         if not dry_run:
-            self.remove_undefined_connections(interfaces)
+            self.remove_undefined_connections(interfaces, keep_masks)
         for iface in interfaces:
             handler = self.handlers.get(iface["type"])
             if handler is not None:

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -599,7 +599,7 @@ class NetworkManagerAdapter:
 
             id = c_settings.get_opt("connection.id")
             if any(mask in id for mask in keep_masks):
-                break
+                continue
 
             for handler in self.handlers.values():
                 if (c_settings.get_opt("connection.uuid") not in uids) and handler.can_manage(c_settings):

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -597,8 +597,8 @@ class NetworkManagerAdapter:
         for con in self.network_manager.get_connections():
             c_settings = DBUSSettings(con.get_settings())
 
-            id = c_settings.get_opt("connection.id")
-            if any(mask in id for mask in keep_masks):
+            с_id = c_settings.get_opt("connection.id")
+            if keep_masks and any(mask in с_id for mask in keep_masks):
                 continue
 
             for handler in self.handlers.values():
@@ -606,7 +606,7 @@ class NetworkManagerAdapter:
                     con.delete()
                     break
 
-    def apply(self, interfaces, dry_run: bool, keep_masks: List = []) -> bool:
+    def apply(self, interfaces, dry_run: bool, keep_masks: List = None) -> bool:
         if not dry_run:
             self.remove_undefined_connections(interfaces, keep_masks)
         for iface in interfaces:


### PR DESCRIPTION
Починила удаление дефолтных gsm соединений если происходит перезапись настроек при выключенном модеме. Если модем выключен, то удаление дефолтных gsm соединений игнорируется
Добавила юнит-тесты на это