### PR TITLE
Fix gsm options visibility 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.33.8) stable; urgency=medium
+
+  * Fix username, password and PIN gsm settings visibility
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 13 Aug 2024 18:26:54 +0300
+
 wb-nm-helper (1.33.7) stable; urgency=medium
 
   * Add unit tests for wb-mqtt-nm-helper

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -1008,17 +1008,32 @@
                         "gsm_username": {
                             "type": "string",
                             "title": "Username used to authenticate with the network",
-                            "propertyOrder": 6
+                            "propertyOrder": 6,
+                            "options":{
+                                "wb": {
+                                    "show_editor": true
+                                }
+                            }
                         },
                         "gsm_password": {
                             "type": "string",
                             "title": "Password used to authenticate with the network",
-                            "propertyOrder": 7
+                            "propertyOrder": 7,
+                            "options":{
+                                "wb": {
+                                    "show_editor": true
+                                }
+                            }
                         },
                         "gsm_pin": {
                             "type": "string",
                             "title": "PIN if the SIM is locked",
-                            "propertyOrder": 8
+                            "propertyOrder": 8,
+                            "options":{
+                                "wb": {
+                                    "show_editor": true
+                                }
+                            }
                         },
                         "ipv4": {
                             "title": "IPv4",


### PR DESCRIPTION
Фикс видимости опций username password и PIN у gsm соединений, они почему то мигали, то есть то нет