### PR TITLE
Monitor mosquitto restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.coveragerc
 
 # Translations
 *.mo

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@ buildDebArchAll defaultRunPythonChecks: true,
                 defaultAngryPylint: true,
                 defaultRunLintian: true,
                 defaultRunCoverage: true,
-                defaultCoverageMin: "76"
+                defaultCoverageMin: "75"
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-nm-helper (1.34.1) stable; urgency=medium
 
-  * Rebublicate mqtt devices after mosquitto restart 
+  * Rebublish mqtt devices after mosquitto restart 
 
  --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 12 Sep 2024 10:13:46 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
+wb-nm-helper (1.34.1) stable; urgency=medium
+
+  * Rebublicate mqtt devices after mosquitto restart 
+
+ --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 12 Sep 2024 10:13:46 +0300
+
 wb-nm-helper (1.34.0) stable; urgency=medium
 
   * Source code refactoring
   * Fix gsm data publication on wb-gsm restart
 
- --  Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Mon, 02 Sep 2024 15:17:40 +0300
+ --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 02 Sep 2024 15:17:40 +0300
 
 wb-nm-helper (1.33.10) stable; urgency=medium
 

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -1018,7 +1018,7 @@ class ActiveConnection:  # pylint: disable=R0902
         logging.info("Remove active connection %s %s", self.connection_path, self._path)
 
 
-class MosquittoMonitor:
+class MosquittoMonitor:  # pylint: disable=R0903
     def __init__(self, mediator: Mediator, mqtt_client: MQTTClient):
         self._mediator = mediator
         self._mqtt_client = mqtt_client
@@ -1086,7 +1086,7 @@ def main():
     wbmqtt.remove_topics_by_device_prefix(mqtt_client, MQTT_DEVICE_TOPIC_PREFIX)
 
     connections_mediator = ConnectionsMediator(mqtt_client)
-    mosquitto_monitor = MosquittoMonitor(connections_mediator, mqtt_client)
+    mosquitto_monitor = MosquittoMonitor(connections_mediator, mqtt_client)  # pylint: disable=unused-variable
 
     def stop_virtual_connections_client(_, __):
         connections_mediator.stop()

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -372,7 +372,7 @@ class ConnectionsMediator(Mediator):  # pylint: disable=R0902
 
     def _reload_connections(self) -> None:
         for connection in self._common_connections.values():
-            connection.republicate()
+            connection.rebublish()
 
     def _update_common_connection(self, connection_path: str, state: MqttConnectionState) -> None:
         connection = self._common_connections.get(connection_path)
@@ -607,10 +607,10 @@ class CommonConnection:  # pylint: disable=R0902
         logging.info("New virtual device %s %s %s", self._name, self._uuid, self._path)
 
     # re-publish all device topics (including meta) and renew subscriptions
-    def republicate(self) -> None:
-        self._mqtt_device.republicate_device()
+    def republish(self) -> None:
+        self._mqtt_device.republish_device()
         self._mqtt_device.add_control_message_callback("UpDown", self._updown_message_callback)
-        logging.info("Republicate virtual device %s %s %s", self._name, self._uuid, self._path)
+        logging.info("Republish virtual device %s %s %s", self._name, self._uuid, self._path)
 
     # update controls values from state
     def update(self, state: MqttConnectionState) -> None:

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -609,6 +609,7 @@ class CommonConnection:  # pylint: disable=R0902
     # re-publish all device topics (including meta) and renew subscriptions
     def republicate(self) -> None:
         self._mqtt_device.republicate_device()
+        self._mqtt_device.add_control_message_callback("UpDown", self._updown_message_callback)
         logging.info("Republicate virtual device %s %s %s", self._name, self._uuid, self._path)
 
     # update controls values from state

--- a/wb/nm_helper/virtual_devices.py
+++ b/wb/nm_helper/virtual_devices.py
@@ -184,6 +184,7 @@ class ConnectionsMediator(Mediator):  # pylint: disable=R0902
 
         self._set_connections_event_handlers()
         self._deactivation_monitor = DeactivationMonitor(self)
+        self._mosquitto_monitor = MosquittoMonitor(self, mqtt_client)
 
     def run(self):
         self._event_loop.run()
@@ -1086,7 +1087,6 @@ def main():
     wbmqtt.remove_topics_by_device_prefix(mqtt_client, MQTT_DEVICE_TOPIC_PREFIX)
 
     connections_mediator = ConnectionsMediator(mqtt_client)
-    mosquitto_monitor = MosquittoMonitor(connections_mediator, mqtt_client)  # pylint: disable=unused-variable
 
     def stop_virtual_connections_client(_, __):
         connections_mediator.stop()

--- a/wb/nm_helper/wbmqtt.py
+++ b/wb/nm_helper/wbmqtt.py
@@ -24,9 +24,17 @@ class Device:
     def __init__(self, mqtt_client, device_mqtt_name: str, device_title: str, driver_name: str) -> None:
         self._mqtt_client = mqtt_client
         self._base_topic = f"/devices/{device_mqtt_name}"
+        self._device_title = device_title
+        self._driver_name = driver_name
         self._controls = {}
         self._publish(self._base_topic + "/meta/name", device_title)
         self._publish(self._base_topic + "/meta/driver", driver_name)
+
+    def republicate_device(self):
+        self._publish(self._base_topic + "/meta/name", self._device_title)
+        self._publish(self._base_topic + "/meta/driver", self._driver_name)
+        for mqtt_control_name in self._controls.copy():
+            self.republicate_control(mqtt_control_name)
 
     def remove_device(self) -> None:
         self._publish(self._base_topic + "/meta/driver", None)
@@ -38,6 +46,13 @@ class Device:
         self._controls[mqtt_control_name] = ControlState(meta, None)
         self._publish_control_meta(mqtt_control_name, meta)
         self.set_control_value(mqtt_control_name, value)
+
+    def republicate_control(self, mqtt_control_name: str) -> None:
+        if mqtt_control_name in self._controls:
+            control = self._controls[mqtt_control_name]
+            if control:
+                self._publish_control_meta(mqtt_control_name, control.meta)
+                self.set_control_value(mqtt_control_name, control.value, force=True)
 
     def remove_control(self, mqtt_control_name: str) -> None:
         if mqtt_control_name in self._controls:

--- a/wb/nm_helper/wbmqtt.py
+++ b/wb/nm_helper/wbmqtt.py
@@ -30,11 +30,11 @@ class Device:
         self._publish(self._base_topic + "/meta/name", device_title)
         self._publish(self._base_topic + "/meta/driver", driver_name)
 
-    def republicate_device(self):
+    def republish_device(self):
         self._publish(self._base_topic + "/meta/name", self._device_title)
         self._publish(self._base_topic + "/meta/driver", self._driver_name)
         for mqtt_control_name in self._controls.copy():
-            self.republicate_control(mqtt_control_name)
+            self.republish_control(mqtt_control_name)
 
     def remove_device(self) -> None:
         self._publish(self._base_topic + "/meta/driver", None)
@@ -47,7 +47,7 @@ class Device:
         self._publish_control_meta(mqtt_control_name, meta)
         self.set_control_value(mqtt_control_name, value)
 
-    def republicate_control(self, mqtt_control_name: str) -> None:
+    def republish_control(self, mqtt_control_name: str) -> None:
         if mqtt_control_name in self._controls:
             control = self._controls[mqtt_control_name]
             if control:


### PR DESCRIPTION
Проблема всех тестов публикатора состоит в том, что сам публикатор надо запускать в отдельном процессе чтобы работал dbus, а библиотека для разделения памяти плохо работает с Mock-объектами и не получается изнутри тестов получить доступ к mqtt_client и mediator. Только непосредственно к публикациям и к интерфейсу dbus. Поэтому не получится дернуть on_connect и on_disconnect из тестов и посмотреть что вызывается перепубликация. Если только интеграционный тест писать.