### PR TITLE
Disable IPv6 for new GSM-connections

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.34.5) stable; urgency=medium
+
+  * 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 14 Oct 2024 11:33:13 +0500
+
 wb-nm-helper (1.34.4) stable; urgency=medium
 
   * Fix connection check with HTTPS URL

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-nm-helper (1.34.5) stable; urgency=medium
 
-  * 
+  * Disable IPv6 for new GSM-connections
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 14 Oct 2024 11:33:13 +0500
 

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -280,6 +280,12 @@ def test_wifiap_set_dbus_options(json, dbus_old, dbus_new):
                         },
                         signature=dbus.Signature("sv"),
                     ),
+                    dbus.String("ipv6"): dbus.Dictionary(
+                        {
+                            dbus.String("method"): "ignore",
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
                 },
                 signature=dbus.Signature("sa{sv}"),
             ),
@@ -346,6 +352,12 @@ def test_wifiap_set_dbus_options(json, dbus_old, dbus_new):
                     dbus.String("ipv4"): dbus.Dictionary(
                         {
                             dbus.String("method"): "auto",
+                        },
+                        signature=dbus.Signature("sv"),
+                    ),
+                    dbus.String("ipv6"): dbus.Dictionary(
+                        {
+                            dbus.String("method"): "ignore",
                         },
                         signature=dbus.Signature("sv"),
                     ),

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -496,6 +496,8 @@ class ModemConnection(Connection):
         # pin is removed
         if not iface.get_opt("gsm.pin") and had_pin:
             clear_secrets = True
+        # use only ipv4
+        con.set_value("ipv6.method", "ignore")
         return SetDbusOptionsResult(clear_secrets)
 
     def get_connection(self, con: NMConnection):


### PR DESCRIPTION
Отключил IPv6 для новых gsm-соединений.

Мотивация [тут](https://wirenboard.youtrack.cloud/issue/SOFT-4270/V-relize-2407-gsm-ne-podklyuchaetsya-bez-ukazaniya-APN), читать комментарии к задаче