### PR TITLE
Fix unexpected GSM-connection deactivation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.34.6) stable; urgency=medium
+
+  * Fix unexpected GSM-connection deactivation after reboot
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 15 Oct 2024 11:34:20 +0500
+
 wb-nm-helper (1.34.5) stable; urgency=medium
 
   * Disable IPv6 for new GSM-connections

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -502,6 +502,13 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         # So deactivate active connection if it exists
         active_connection = dev.get_active_connection()
         if active_connection:
+            if active_connection.get_connection_id() == con.get_connection_id():
+                logging.debug("The connection is already activating")
+                if self._wait_connection_activation(
+                    active_connection, self.timeouts.connection_activation_timeout
+                ):
+                    return active_connection
+                return None
             self.deactivate_current_gsm_connection(active_connection)
         else:
             logging.debug("No active gsm connection detected")

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -503,7 +503,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
         active_connection = dev.get_active_connection()
         if active_connection:
             if active_connection.get_connection_id() == con.get_connection_id():
-                logging.debug("The connection is already activating")
+                logging.debug("The connection %s is already activating", con.get_connection_id())
                 if self._wait_connection_activation(
                     active_connection, self.timeouts.connection_activation_timeout
                 ):


### PR DESCRIPTION
There is a race condition between NM and wb-connection-manager. They both want to activate the same connection. If NM wins, wb-connection-manager detects already active connection, deactivates it and activates again