### PR TITLE
Fix psk max length

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.34.8) stable; urgency=medium
+
+  * Fix psk max length
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 04 Dec 2024 19:30:00 +0400
+
 wb-nm-helper (1.34.7) stable; urgency=medium
 
   * Hide passwords

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -91,8 +91,9 @@
                             "type": "string",
                             "format": "password",
                             "title": "Password",
+                            "description": "Passphrase or PBKDF2 key",
                             "minLength": 8,
-                            "maxLength": 63,
+                            "maxLength": 64,
                             "propertyOrder": 2
                         },
                         "encryption": {
@@ -1622,6 +1623,7 @@
             "Wi-Fi access point": "Wi-Fi точка доступа",
             "mac-pattern-message": "Необходимо задать шесть байт в шестнадцатеричном виде, разделённых двоеточием (например f2:c8:14:48:d3:97)",
             "Password": "Пароль",
+            "Passphrase or PBKDF2 key": "Парольная фраза или PBKDF2-ключ",
             "Security": "Защита",
             "Network name (SSID)": "Название сети (SSID)",
             "None": "Нет",


### PR DESCRIPTION
Согласно https://www.networkmanager.dev/docs/api/latest/settings-802-11-wireless-security.html:
> **psk**
> _string_
> Pre-Shared-Key for WPA networks. For WPA-PSK, it's either an ASCII passphrase of 8 to 63 characters that is (as specified in the 802.11i standard) hashed to derive the actual key, or the key in form of 64 hexadecimal character. The WPA3-Personal networks use a passphrase of any length for SAE authentication.

Чтобы не хранить пароль в открытом виде на контроллере генерирую PSK ключ:
```sh
$ wpa_passphrase wirenboard-AWB8TEST wirenboard
network={
	ssid="wirenboard-AWB8TEST"
	#psk="wirenboard"
	psk=32d74d5de70c6f286f499fa3f8ebb0fa607256a28346ada3a4f098269c6e0483
}
```

Текущее поведение:
1. Пытаюсь его задать в качестве пароля в UI => последний символ обрезается при сохранении и ничего не работает.
2. Пытаюсь вручную задать ключ как wifi-security.psk в .nmconnection конфиге => редактор соединений перестает открываться.

Поведение после:
Оба варианта (с паролем и с ключем) работают.
<img width="384" alt="Näyttökuva 2024-12-4 kello 21 51 59" src="https://github.com/user-attachments/assets/efbbac57-3943-4153-8432-a49a4e003adf">
