### PR TITLE
Fix removing dns settings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 wb-nm-helper (1.34.8) stable; urgency=medium
 
+  * Fix removing dns settings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 17 Dec 2024 09:20:00 +0400
+
+wb-nm-helper (1.34.8) stable; urgency=medium
+
   * Fix psk max length
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 04 Dec 2024 19:30:00 +0400

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-nm-helper (1.34.8) stable; urgency=medium
+wb-nm-helper (1.34.9) stable; urgency=medium
 
   * Fix removing dns settings
 

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -256,6 +256,9 @@ def set_ipv4_dbus_options(con: DBUSSettings, iface: JSONSettings) -> None:
     else:
         con.set_value("ipv4.address-data", None)
 
+    if not iface.get_opt("ipv4.dns"):
+        con.set_value("ipv4.dns-data", None)
+
 
 def get_ipv4_dbus_options(res: JSONSettings, cfg: DBUSSettings) -> None:
     res.set_opts(cfg, ipv4_params)


### PR DESCRIPTION
https://www.networkmanager.dev/docs/api/latest/settings-ipv4.html:
> **dns**
> _array of uint32_
> 	Array of IP addresses of DNS servers (as network-byte-order integers)
> 
> **dns-data**
> _array of strings_
> 	Array of DNS name servers. This replaces the deprecated "dns" property. Each name server can also contain a DoT server name.

По факту при получении настроек из dbus приходят оба, а при сохранении выставляем только dns. Но в случае удаления получалось что dns удаляем, а старый dns-data остается. В итоге в .nmconnection конфиге ipv4.dns не удаляется.