### PR TITLE
Add option to hide wifi network SSID in AP mode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.35.1) stable; urgency=medium
+
+  * Add option to hide wifi network SSID in AP mode
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Sun, 29 Jun 2025 20:30:00 +0400
+
 wb-nm-helper (1.35.0) stable; urgency=medium
 
   * Exclude shared ethernet connections from switching

--- a/tests/connections_settings.py
+++ b/tests/connections_settings.py
@@ -105,6 +105,7 @@ WB_AP_DBUS_SETTINGS = dbus.Dictionary(
             {
                 "mode": dbus.String("ap", variant_level=1),
                 "ssid": dbus.ByteArray(bytes("WirenBoard-Тест", encoding="utf8")),
+                "hidden": dbus.Boolean(False, variant_level=1),
             },
             signature=dbus.Signature("sv"),
         ),

--- a/tests/data/ui.json
+++ b/tests/data/ui.json
@@ -84,6 +84,7 @@
         },
         "802-11-wireless_mode": "ap",
         "802-11-wireless_ssid": "WirenBoard-XXXXXXXX",
+        "802-11-wireless_hidden": false,
         "connection_interface-name": "wlan0",
         "ipv4": {
           "address": "192.168.42.1",

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -18,6 +18,7 @@ from wb.nm_helper.network_manager_adapter import (
                 "802-11-wireless-security": {"security": "none"},
                 "802-11-wireless_mode": "ap",
                 "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
+                "802-11-wireless_hidden": False,
                 "connection_interface-name": "wlan0",
                 "ipv4": {"method": "shared"},
                 "type": "04_nm_wifi_ap",
@@ -44,6 +45,7 @@ from wb.nm_helper.network_manager_adapter import (
                             dbus.String("mode"): dbus.String("ap", variant_level=1),
                             dbus.String("security"): dbus.String("802-11-wireless-security", variant_level=1),
                             dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                            dbus.String("hidden"): dbus.Boolean(False, variant_level=1),
                             dbus.String("powersave"): dbus.Int32(2, variant_level=1),
                         },
                         signature=dbus.Signature("sv"),
@@ -83,6 +85,7 @@ from wb.nm_helper.network_manager_adapter import (
                         {
                             dbus.String("mode"): "ap",
                             dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                            dbus.String("hidden"): dbus.Boolean(False, variant_level=1),
                             dbus.String("powersave"): dbus.Int32(2, variant_level=1),
                         },
                         signature=dbus.Signature("sv"),
@@ -111,6 +114,7 @@ from wb.nm_helper.network_manager_adapter import (
                 "802-11-wireless-security": {"security": "none"},
                 "802-11-wireless_mode": "ap",
                 "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
+                "802-11-wireless_hidden": False,
                 "connection_interface-name": "wlan0",
                 "ipv4": {"method": "shared", "address": "192.168.42.1"},
                 "type": "04_nm_wifi_ap",
@@ -136,6 +140,7 @@ from wb.nm_helper.network_manager_adapter import (
                         {
                             dbus.String("mode"): dbus.String("ap", variant_level=1),
                             dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                            dbus.String("hidden"): dbus.Boolean(False, variant_level=1),
                             dbus.String("powersave"): dbus.Int32(2, variant_level=1),
                         },
                         signature=dbus.Signature("sv"),
@@ -171,6 +176,7 @@ from wb.nm_helper.network_manager_adapter import (
                         {
                             dbus.String("mode"): "ap",
                             dbus.String("ssid"): dbus.ByteArray(b"WirenBoard-APT6KWYK"),
+                            dbus.String("hidden"): dbus.Boolean(False, variant_level=1),
                             dbus.String("powersave"): dbus.Int32(2, variant_level=1),
                         },
                         signature=dbus.Signature("sv"),

--- a/tests/test_nm_helper.py
+++ b/tests/test_nm_helper.py
@@ -82,6 +82,7 @@ class TestNetworkManagerHelperImport(dbusmock.DBusTestCase):
         assert res["ui"]["connections"][0]["802-11-wireless-security"]["security"] == "none"
         assert res["ui"]["connections"][0]["802-11-wireless_mode"] == "ap"
         assert res["ui"]["connections"][0]["802-11-wireless_ssid"] == "WirenBoard-Тест"
+        assert res["ui"]["connections"][0]["802-11-wireless_hidden"] is False
         assert res["ui"]["connections"][0]["connection_autoconnect"] is True
         assert res["ui"]["connections"][0]["connection_id"] == "wb-ap"
         assert res["ui"]["connections"][0]["connection_interface-name"] == "wlan0"

--- a/wb-network.schema.json
+++ b/wb-network.schema.json
@@ -882,26 +882,33 @@
                             "propertyOrder": 4,
                             "minLength": 1
                         },
+                        "802-11-wireless_hidden": {
+                            "title": "Hide SSID",
+                            "type": "boolean",
+                            "default": false,
+                            "_format": "checkbox",
+                            "propertyOrder": 5
+                        },
                         "802-11-wireless-security": {
                             "$ref": "#/definitions/802-11-wireless-security",
-                            "propertyOrder": 5
+                            "propertyOrder": 6
                         },
                         "nat": {
                             "title": "Share Internet connection",
                             "type": "boolean",
                             "default": true,
                             "_format": "checkbox",
-                            "propertyOrder": 6
+                            "propertyOrder": 7
                         },
                         "ipv4": {
                             "title": "IPv4",
                             "$ref": "#/definitions/nm_ipv4_shared",
-                            "propertyOrder": 7
+                            "propertyOrder": 8
                         },
                         "connection_interface-name": {
                             "type": "string",
                             "title": "Only for interface",
-                            "propertyOrder": 8,
+                            "propertyOrder": 9,
                             "options": {
                                 "inputAttributes": {
                                     "placeholder":  "use with any suitable interface"
@@ -927,7 +934,7 @@
                             "type": "string",
                             "title": "Band",
                             "description": "802-11-wireless_band_desc",
-                            "propertyOrder": 9,
+                            "propertyOrder": 10,
                             "options": {
                                 "wb": {
                                     "disabledEditorText":  "auto"
@@ -951,7 +958,7 @@
                             "description": "802-11-wireless_channel_desc",
                             "minimum": 1,
                             "default": 1,
-                            "propertyOrder": 10,
+                            "propertyOrder": 11,
                             "options": {
                                 "wb": {
                                     "disabledEditorText":  "auto"
@@ -961,10 +968,10 @@
                         },
                         "802-11-wireless_mtu": {
                             "$ref": "#/definitions/mtu",
-                            "propertyOrder": 11
+                            "propertyOrder": 12
                         }
                     },
-                    "required": ["type", "nat", "802-11-wireless_ssid", "802-11-wireless_mode", "802-11-wireless-security", "ipv4"]
+                    "required": ["type", "nat", "802-11-wireless_ssid", "802-11-wireless_hidden", "802-11-wireless_mode", "802-11-wireless-security", "ipv4"]
                 },
                 {
                     "$ref": "#/definitions/nm_connection"
@@ -1629,6 +1636,7 @@
             "None": "Нет",
             "Shared to other computers": "Общий с другими компьютерами",
             "Type": "Тип",
+            "Hide SSID": "Скрыть SSID",
             "Share Internet connection": "Раздавать интернет",
             "Deny GSM/Wi-Fi connections switching period (seconds)": "Не переключать SIM-слот или Wi-Fi-сеть в течение этого периода (секунды)",
             "After successfully establishing a modem/Wi-Fi connection, do not try changing SIM slot or change to another Wi-Fi network for this amount of seconds": "После успешного подключения через модем или Wi-Fi, не пытаться менять SIM-слот или Wi-Fi-соединение даже на более приоритетные в течение этого количества секунд",

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -417,6 +417,7 @@ class WiFiAp(WiFiConnection):
         params = [
             Param("802-11-wireless.band"),
             Param("802-11-wireless.channel"),
+            Param("802-11-wireless.hidden", from_dbus=to_bool_default_false),
         ]
         WiFiConnection.__init__(self, params)
         self.ui_type = METHOD_WIFI_AP


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Опция для скрытия SSID точки, как это возможно на большинстве раутеров. Иногда бывает полезно.

___________________________________
**Что поменялось для пользователей:**
Появился чекбокс для скрытия SSID:
![Screen Shot 2025-06-29 at 22 59 04](https://github.com/user-attachments/assets/c92abf23-c110-45f7-846e-dcd1aa32b3af)
![Screen Shot 2025-06-29 at 22 59 26](https://github.com/user-attachments/assets/8ecb2159-980d-4442-83b6-56295def027b)

```sh
grep -A4 "\[wifi\]" /etc/NetworkManager/system-connections/wb-ap.nmconnection
[wifi]
band=bg
channel=1
hidden=true
mode=ap
```
___________________________________
**Как проверял/а:**
На контроллере
