### PR TITLE
Restart wb-mqtt-nm-helper on failure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.38.1) stable; urgency=medium
+
+  * Restart wb-mqtt-nm-helper on failure
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 02 Jul 2026 12:00:00 +0400
+
 wb-nm-helper (1.38.0) stable; urgency=medium
 
   * Migrate from pycares to dnspython

--- a/debian/wb-nm-helper.wb-mqtt-nm-helper.service
+++ b/debian/wb-nm-helper.wb-mqtt-nm-helper.service
@@ -4,6 +4,8 @@ After=NetworkManager.service mosquitto.service
 
 [Service]
 Type=simple
+Restart=on-failure
+RestartSec=2
 User=root
 ExecStart=/usr/bin/wb-mqtt-nm-helper
 ExecReload=/usr/bin/wb-mqtt-nm-helper --reload $MAINPID


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
на wb6 сервис с первого раза не стартовал и так остался без рестарта:

<img width="1760" height="477" alt="Screen Shot 2026-07-02 at 12 51 04" src="https://github.com/user-attachments/assets/4258e0bb-cb18-45e4-bd3d-c63e39ec6255" />

ручной рестарт помог
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на wb6

