### PR TITLE
Recover connectivity after NM deactivates the current connection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 wb-nm-helper (1.38.2) stable; urgency=medium
 
-  * Re-activate the current connection after NM deactivates it
+  * Recover connectivity after NM deactivates the current connection
 
- -- Ilya Titov <ilya.titov@wirenboard.com>  Mon, 20 Jul 2026 09:28:46 +0300
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Mon, 20 Jul 2026 11:14:00 +0300
 
 wb-nm-helper (1.38.1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.38.2) stable; urgency=medium
+
+  * Re-activate the current connection after NM deactivates it
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Mon, 20 Jul 2026 09:28:46 +0300
+
 wb-nm-helper (1.38.1) stable; urgency=medium
 
   * Restart wb-mqtt-nm-helper on failure

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -863,7 +863,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.find_activated_connection = MagicMock(return_value="active")
+        self.con_man.find_activated_connection = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[True])
         self.assertEqual((low_tier, "wb_wifi_client"), self.con_man.check())
@@ -882,7 +882,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.find_activated_connection = MagicMock(return_value="active")
+        self.con_man.find_activated_connection = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[False, False])
         self.assertEqual((high_tier, "wb_eth0"), self.con_man.check())

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -863,7 +863,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.current_connection_is_active = MagicMock(return_value=True)
+        self.con_man.find_activated_connection = MagicMock(return_value="active")
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[True])
         self.assertEqual((low_tier, "wb_wifi_client"), self.con_man.check())
@@ -882,7 +882,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.current_connection_is_active = MagicMock(return_value=True)
+        self.con_man.find_activated_connection = MagicMock(return_value="active")
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[False, False])
         self.assertEqual((high_tier, "wb_eth0"), self.con_man.check())

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -863,7 +863,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.find_activated_connection = MagicMock(return_value=True)
+        self.con_man.current_connection_is_active = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[True])
         self.assertEqual((low_tier, "wb_wifi_client"), self.con_man.check())
@@ -882,7 +882,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
-        self.con_man.find_activated_connection = MagicMock(return_value=True)
+        self.con_man.current_connection_is_active = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[False, False])
         self.assertEqual((high_tier, "wb_eth0"), self.con_man.check())

--- a/tests/test_connection_manager_units.py
+++ b/tests/test_connection_manager_units.py
@@ -863,6 +863,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
+        self.con_man.current_connection_is_active = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[True])
         self.assertEqual((low_tier, "wb_wifi_client"), self.con_man.check())
@@ -881,6 +882,7 @@ class ConnectionManagerTests(TestCase):
 
         self.con_man.timeouts.debug_log_timeouts = MagicMock()
         self.con_man.current_connection_has_connectivity = MagicMock(return_value=False)
+        self.con_man.current_connection_is_active = MagicMock(return_value=True)
         self.con_man.connection_has_connectivity = MagicMock(return_value=False)
         self.con_man.try_to_activate_and_check = MagicMock(side_effect=[False, False])
         self.assertEqual((high_tier, "wb_eth0"), self.con_man.check())

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -374,6 +374,13 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             or cn_id != self.current_connection
         )
 
+    def current_connection_is_active(self) -> bool:
+        try:
+            return self.find_activated_connection(self.current_connection) is not None
+        except dbus.exceptions.DBusException as ex:
+            self._log_connection_check_error(self.current_connection, ex)
+            return True
+
     def check(self) -> (ConnectionTier, str):
         logging.debug("check(): starting iteration")
         self.timeouts.debug_log_timeouts()
@@ -383,6 +390,11 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             if self.current_tier and self.current_connection and self.current_tier.priority == tier.priority:
                 if self.current_connection_has_connectivity():
                     return self.current_tier, self.current_connection
+                # Deactivated by NM behind our back: drop stale pointer so it can be re-activated
+                if not self.current_connection_is_active():
+                    logging.info("Current connection %s was deactivated, re-activating", self.current_connection)
+                    self.current_connection = None
+                    self.current_tier = None
 
             # find already active connection in tier
             for cn_id in tier.connections:

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -374,13 +374,6 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             or cn_id != self.current_connection
         )
 
-    def current_connection_is_active(self) -> bool:
-        try:
-            return self.find_activated_connection(self.current_connection) is not None
-        except dbus.exceptions.DBusException as ex:
-            self._log_connection_check_error(self.current_connection, ex)
-            return True
-
     def check(self) -> (ConnectionTier, str):
         logging.debug("check(): starting iteration")
         self.timeouts.debug_log_timeouts()
@@ -391,7 +384,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                 if self.current_connection_has_connectivity():
                     return self.current_tier, self.current_connection
                 # Deactivated by NM behind our back: drop stale pointer so it can be re-activated
-                if not self.current_connection_is_active():
+                if not self.find_activated_connection(self.current_connection):
                     logging.info(
                         "Current connection %s was deactivated, re-activating", self.current_connection
                     )

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -390,10 +390,11 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             if self.current_tier and self.current_connection and self.current_tier.priority == tier.priority:
                 if self.current_connection_has_connectivity():
                     return self.current_tier, self.current_connection
-                # Deactivated by NM behind our back: drop stale pointer so it can be re-activated
+                # Deactivated by NM behind our back: drop stale pointer so check() can reselect
                 if not self.current_connection_is_active():
                     logging.info(
-                        "Current connection %s was deactivated, re-activating", self.current_connection
+                        "Current connection %s is no longer active, looking for a connection to activate",
+                        self.current_connection,
                     )
                     self.current_connection = None
                     self.current_tier = None

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -392,7 +392,9 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                     return self.current_tier, self.current_connection
                 # Deactivated by NM behind our back: drop stale pointer so it can be re-activated
                 if not self.current_connection_is_active():
-                    logging.info("Current connection %s was deactivated, re-activating", self.current_connection)
+                    logging.info(
+                        "Current connection %s was deactivated, re-activating", self.current_connection
+                    )
                     self.current_connection = None
                     self.current_tier = None
 

--- a/wb/nm_helper/connection_manager.py
+++ b/wb/nm_helper/connection_manager.py
@@ -374,6 +374,13 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
             or cn_id != self.current_connection
         )
 
+    def current_connection_is_active(self) -> bool:
+        try:
+            return self.find_activated_connection(self.current_connection) is not None
+        except dbus.exceptions.DBusException as ex:
+            self._log_connection_check_error(self.current_connection, ex)
+            return False
+
     def check(self) -> (ConnectionTier, str):
         logging.debug("check(): starting iteration")
         self.timeouts.debug_log_timeouts()
@@ -384,7 +391,7 @@ class ConnectionManager:  # pylint: disable=too-many-instance-attributes disable
                 if self.current_connection_has_connectivity():
                     return self.current_tier, self.current_connection
                 # Deactivated by NM behind our back: drop stale pointer so it can be re-activated
-                if not self.find_activated_connection(self.current_connection):
+                if not self.current_connection_is_active():
                     logging.info(
                         "Current connection %s was deactivated, re-activating", self.current_connection
                     )


### PR DESCRIPTION
## Проблема

Если NetworkManager деактивирует текущее соединение сам (например, оператор рвёт GSM/PPP-сессию), оно исчезает из NM, но `current_connection` всё ещё указывает на него. Обе петли активации в `check()` пропускают его через `is_not_current_connection()` как «текущее» — поэтому его никто не переподнимает. Если рабочей альтернативы нет (GSM в низшем тире, ethernet без линка), аплинк остаётся лежать до ручного «Подключить».

В полевом инциденте на WB8 это дало ~3 суток без интернета: `LCP terminated by peer` → NM автоповтор упал с `unable to determine the network id` (модем на миг дерегистрировался) → CM залип на мёртвом `wb-gsm-sim1`, крутя только недоступный `wb-eth1`.

## Фикс

В `check()`, когда текущее соединение без связности: проверяем, живо ли оно в NM (`current_connection_is_active()`). Если деактивировано — сбрасываем указатель, и обычная петля активации переподнимает его. Случай «активно, но без интернета» не трогаем.

## Проверка на железе (A7602E, 1.37.1)

GSM — единственный управляемый аплинк, обрыв через `nmcli connection down wb-gsm-sim1`:

| | без фикса | с фиксом |
|---|---|---|
| GSM после обрыва | `disconnected` навсегда | переподнят автоматически |
| задержка | — | ≤1 цикл (~5 c), максимум ~60 c (`connection_retry_timeout`) |