### PR TITLE
Disable PMF for Wi-Fi access point for RTL8723BU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-nm-helper (1.38.3) stable; urgency=medium
+
+  * Disable PMF for Wi-Fi access point for RTL8723BU
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 29 Jul 2026 12:00:00 +0400
+
 wb-nm-helper (1.38.2) stable; urgency=medium
 
   * Recover connectivity after NM deactivates the current connection

--- a/tests/test_network_manager_adapter.py
+++ b/tests/test_network_manager_adapter.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import dbus
 import pytest
 
@@ -5,7 +7,9 @@ from wb.nm_helper.network_manager_adapter import (
     DBUSSettings,
     JSONSettings,
     ModemConnection,
+    NetworkManagerAdapter,
     WiFiAp,
+    has_rtl8723bu,
 )
 
 
@@ -217,6 +221,89 @@ def test_wifiap_set_dbus_options(json, dbus_old, dbus_new):
     res = access_point.set_dbus_options(dbus_old_settings, json_settings)
     assert getattr(res, "clear_secrets") is False
     assert dbus_old_settings.params == dbus_new_settings.params
+
+
+def make_network_manager(drivers):
+    network_manager = MagicMock()
+    devices = []
+    for driver in drivers:
+        device = MagicMock()
+        device.get_property.return_value = driver
+        devices.append(device)
+    network_manager.get_devices.return_value = devices
+    return network_manager
+
+
+@pytest.mark.parametrize(
+    "drivers,expected",
+    [
+        (["rtl8723bu", "rtl8723bu"], True),
+        (["rtl8733bu", "rtl8733bu"], False),
+        (["rtl8733bu", "rtl8723bu"], True),
+        ([], False),
+    ],
+)
+def test_has_rtl8723bu(drivers, expected):
+    assert has_rtl8723bu(make_network_manager(drivers)) is expected
+
+
+@pytest.mark.parametrize(
+    "drivers,expected_bands",
+    [
+        # rtl8723bu claims a 5GHz support it does not have
+        (["rtl8723bu", "rtl8723bu"], ["bg"]),
+        (["rtl8733bu", "rtl8733bu"], ["bg", "a"]),
+    ],
+)
+def test_get_wifi_bands(drivers, expected_bands):
+    with patch(
+        "wb.nm_helper.network_manager_adapter.NetworkManager",
+        return_value=make_network_manager(drivers),
+    ):
+        assert NetworkManagerAdapter().get_wifi_bands() == expected_bands
+
+
+@pytest.mark.parametrize(
+    "drivers,expected_pmf",
+    [
+        # rtl8723bu has no 802.11w support at all, PMF must be turned off explicitly
+        (["rtl8723bu", "rtl8723bu"], 1),
+        # rtl8733bu can do 802.11w, so PMF is left at NetworkManager's own default
+        (["rtl8733bu", "rtl8733bu"], None),
+    ],
+)
+def test_wifiap_set_dbus_options_pmf(drivers, expected_pmf):
+    json_settings = JSONSettings(
+        {
+            "802-11-wireless-security": {
+                "security": "wpa-psk",
+                "key-mgmt": "wpa-psk",
+                "psk": "0123456789",
+                "encryption": "AES/CCMP",
+            },
+            "802-11-wireless_mode": "ap",
+            "802-11-wireless_ssid": "WirenBoard-APT6KWYK",
+            "802-11-wireless_hidden": False,
+            "connection_interface-name": "wlan0",
+            "ipv4": {"method": "shared"},
+            "type": "04_nm_wifi_ap",
+            "connection_autoconnect": False,
+            "connection_id": "wb-ap",
+            "connection_uuid": "d12c8d3c-1abe-4832-9b71-4ed6e3c20885",
+        }
+    )
+    dbus_settings = DBUSSettings()
+    with patch(
+        "wb.nm_helper.network_manager_adapter.NetworkManager",
+        return_value=make_network_manager(drivers),
+    ):
+        WiFiAp().set_dbus_options(dbus_settings, json_settings)
+    # the security section must survive, otherwise nothing below is actually checked
+    assert dbus_settings.get_opt("802-11-wireless-security.key-mgmt") == "wpa-psk"
+    assert dbus_settings.get_opt("802-11-wireless-security.psk") == "0123456789"
+    assert dbus_settings.get_opt("802-11-wireless-security.pmf") == expected_pmf
+    # WPS is disabled regardless of the chip
+    assert dbus_settings.get_opt("802-11-wireless-security.wps-method") == 1
 
 
 @pytest.mark.parametrize(

--- a/wb/nm_helper/network_manager_adapter.py
+++ b/wb/nm_helper/network_manager_adapter.py
@@ -32,6 +32,10 @@ METHOD_WIFI = "03_nm_wifi"
 METHOD_WIFI_AP = "04_nm_wifi_ap"
 
 
+def has_rtl8723bu(network_manager: NetworkManager) -> bool:
+    return any(dev.get_property("Driver") == "rtl8723bu" for dev in network_manager.get_devices())
+
+
 class ParamPathType(Enum):
     FLAT = 1
     TREE = 2
@@ -431,6 +435,11 @@ class WiFiAp(WiFiConnection):
         if "802-11-wireless-security" in con.params:
             # Disable WPS as it can lead to connection problems with MacOS and Linux
             con.set_value("802-11-wireless-security.wps-method", 1)
+            # rtl8723bu has no 802.11w support, its wiphy advertises no BIP cipher.
+            # Requesting PMF there makes hostapd install an IGTK at group key index 4,
+            # which cfg80211 rejects, and the access point never starts
+            if has_rtl8723bu(NetworkManager()):
+                con.set_value("802-11-wireless-security.pmf", 1)
         user_data = con.get_opt("user.data", dbus.Dictionary(signature="ss"))
         user_data["wb.disable-nat"] = "false" if iface.get_opt("nat", True) else "true"
         con.set_value("user.data", user_data)
@@ -667,13 +676,9 @@ class NetworkManagerAdapter:
 
     def get_wifi_bands(self) -> List[str]:
         bands = ["bg"]
-        has_rtl8723bu = False
         # rtl8723bu driver reports that it supports both 2.4GHz and 5GHz,
         # so we can't rely here on WirelessCapabilities property
         # of org.freedesktop.NetworkManager.Device.Wireless interface
-        for dev in self.network_manager.get_devices():
-            if dev.get_property("Driver") == "rtl8723bu":
-                has_rtl8723bu = True
-        if not has_rtl8723bu:
+        if not has_rtl8723bu(self.network_manager):
             bands.append("a")
         return bands


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В rtl8723bu драйвере выключена поддержка IEEE 802.11w (см CONFIG_IEEE80211W), даже если ее там включить этого недостаточно, так как не все необходимые виды шифрования поддерживает (см iw phy phy0 info). Новые NM+hostapd в трикси пытаются включить PMF для AP (см https://www.networkmanager.dev/docs/api/latest/settings-802-11-wireless-security.html), в результате точка не поднимается с `nl80211: kernel reports: key setting validation failed`.

___________________________________
**Что поменялось для пользователей:**
wb-ap с паролем на старом чипе поднимается

___________________________________
**Как проверял/а:**
на вб

